### PR TITLE
Ios deployment workflow secrets

### DIFF
--- a/.github/workflows/deploy-ios.yml
+++ b/.github/workflows/deploy-ios.yml
@@ -14,6 +14,8 @@ jobs:
   build-and-deploy:
     runs-on: macos-latest
     environment: production
+    env:
+      MATCH_DEPLOY_KEY: ${{ secrets.MATCH_DEPLOY_KEY }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -36,9 +38,9 @@ jobs:
 
       - name: Setup SSH for certificates repo
         uses: webfactory/ssh-agent@v0.9.1
-        if: ${{ secrets.MATCH_DEPLOY_KEY != '' }}
+        if: ${{ env.MATCH_DEPLOY_KEY != '' }}
         with:
-          ssh-private-key: ${{ secrets.MATCH_DEPLOY_KEY }}
+          ssh-private-key: ${{ env.MATCH_DEPLOY_KEY }}
 
       - name: Sync signing assets (match)
         working-directory: apps/siutindei_app/ios


### PR DESCRIPTION
Fix "Unrecognised named-value: secrets" error in `deploy-ios.yml` by moving `MATCH_DEPLOY_KEY` to job `env`.

GitHub Actions `if` conditions do not directly support accessing the `secrets` context, causing the workflow to fail. Moving the secret to a job-level environment variable allows it to be accessed correctly within the `if` condition and action inputs.

---
<a href="https://cursor.com/background-agent?bcId=bc-35a2b2ef-0963-49b6-ac3a-a935c69c42be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-35a2b2ef-0963-49b6-ac3a-a935c69c42be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

