### PR TITLE
Checkov yaml pickup

### DIFF
--- a/backend/infrastructure/.checkov.yaml
+++ b/backend/infrastructure/.checkov.yaml
@@ -1,6 +1,10 @@
 # Checkov configuration for CDK infrastructure
-# All checkov skips should be centralized in this file
 # See: https://www.checkov.io/2.Basics/Suppressing%20and%20Skipping%20Policies.html
+#
+# IMPORTANT: Checkov's skip-check option does NOT support resource-specific patterns.
+# The format "CKV_ID:RESOURCE_ID" is NOT valid - only check IDs are supported.
+# Resource-specific suppressions must be done via CloudFormation metadata in CDK code.
+# See: lib/api-stack.ts and lib/admin-web-stack.ts for metadata-based suppressions.
 
 # Framework configuration
 framework:
@@ -9,41 +13,33 @@ framework:
 # Soft fail - report issues without failing the build
 soft-fail: true
 
-# Skip checks - add justification for each skipped check
-# Format:
-#   skip-check:
-#     - CKV_AWS_XXX:RESOURCE_ID  # Justification for skipping this check
-#
-# OrganizationImagesBucket skips:
-# This S3 bucket is intentionally configured for public read access to serve
-# organization images (logos, photos). The bucket uses BLOCK_ACLS to prevent
-# ACL-based public access while allowing bucket policy based public read.
-# This is a deliberate design choice for serving static assets.
-# Future improvement: Consider using CloudFront with OAC for better security and caching.
-#
-# Logging bucket skips (AdminWebLoggingBucket, OrganizationImagesLogBucket):
-# These are logging destination buckets that receive access logs from CloudFront
-# and S3. Enabling access logging on a logging bucket would create an infinite
-# loop of log entries. This is a standard AWS pattern.
-#
-# LogRetention Lambda skips:
-# This is a CDK-internal Lambda function automatically created to manage
-# CloudWatch log group retention policies. It's not user-managed code and
-# runs infrequently (only during deployments), so concurrent execution
-# limits are not necessary.
-skip-check:
-  - CKV_AWS_54:AWS::S3::Bucket.OrganizationImagesBucket347D331B  # Public access intentional - serves organization images
-  - CKV_AWS_55:AWS::S3::Bucket.OrganizationImagesBucket347D331B  # Public access intentional - serves organization images
-  - CKV_AWS_56:AWS::S3::Bucket.OrganizationImagesBucket347D331B  # Public access intentional - serves organization images
-  - CKV_AWS_18:AWS::S3::Bucket.AdminWebLoggingBucketF51DF562  # Logging bucket - no self-logging to avoid infinite loop
-  - CKV_AWS_18:AWS::S3::Bucket.OrganizationImagesLogBucket6FCE8FC4  # Logging bucket - no self-logging to avoid infinite loop
-  - CKV_AWS_115:AWS::Lambda::Function.LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A  # CDK internal - runs only during deployments
-  - CKV_AWS_116:AWS::Lambda::Function.LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A  # CDK internal - runs only during deployments
-  - CKV_AWS_117:AWS::Lambda::Function.LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A  # CDK internal - no VPC resources needed
-  - CKV_AWS_111:AWS::IAM::Policy.LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB  # CDK internal - required for log retention management
-
 # Compact output - reduce noise in CI logs
 compact: true
 
 # Download external modules/checks
 download-external-modules: false
+
+# NOTE: All resource-specific suppressions are now handled via CDK metadata:
+#
+# OrganizationImagesBucket (CKV_AWS_54, CKV_AWS_55, CKV_AWS_56):
+#   - Public access is intentional - bucket serves organization images
+#   - Suppressed in api-stack.ts via CfnBucket.addMetadata()
+#
+# AdminWebLoggingBucket, OrganizationImagesLogBucket (CKV_AWS_18):
+#   - Logging buckets cannot have self-logging (infinite loop)
+#   - Suppressed in admin-web-stack.ts and api-stack.ts via CfnBucket.addMetadata()
+#
+# LogRetention Lambda (CKV_AWS_115, CKV_AWS_116, CKV_AWS_117):
+#   - CDK-internal Lambda for log retention management
+#   - Runs only during deployments, no VPC/DLQ/concurrency needed
+#   - Suppressed via CdkInternalLambdaCheckovSuppression Aspect in api-stack.ts
+#
+# LogRetention IAM Policy (CKV_AWS_111):
+#   - CDK-internal policy for log retention management
+#   - Requires write access to manage log groups
+#   - Suppressed via CdkInternalLambdaCheckovSuppression Aspect in api-stack.ts
+#
+# AwsCustomResource Lambda (CKV_AWS_115, CKV_AWS_116, CKV_AWS_117):
+#   - CDK-internal Lambda for custom resource SDK calls
+#   - Runs only during deployments, no VPC/DLQ/concurrency needed
+#   - Suppressed via CdkInternalLambdaCheckovSuppression Aspect in api-stack.ts

--- a/backend/infrastructure/lib/admin-web-stack.ts
+++ b/backend/infrastructure/lib/admin-web-stack.ts
@@ -84,6 +84,17 @@ export class AdminWebStack extends cdk.Stack {
       objectOwnership: s3.ObjectOwnership.BUCKET_OWNER_PREFERRED,
     });
 
+    // Checkov suppression: Logging bucket cannot have self-logging (infinite loop)
+    const loggingBucketCfn = this.loggingBucket.node.defaultChild as s3.CfnBucket;
+    loggingBucketCfn.addMetadata("checkov", {
+      skip: [
+        {
+          id: "CKV_AWS_18",
+          comment: "Logging bucket - enabling access logging would create infinite loop",
+        },
+      ],
+    });
+
     // -------------------------------------------------------------------------
     // Main content bucket with access logging enabled
     // -------------------------------------------------------------------------


### PR DESCRIPTION
Refactor Checkov suppressions to use CloudFormation metadata in CDK code instead of unsupported resource-specific patterns in `.checkov.yaml`.

The `.checkov.yaml` file's `skip-check` entries with resource IDs (e.g., `CKV_AWS_54:AWS::S3::Bucket.LogicalId`) were not working because Checkov only supports global check ID skips via the config file. Resource-specific suppressions must be applied as metadata directly within the CloudFormation template, which this PR now implements for S3 buckets and CDK-internal Lambda functions.

---
<a href="https://cursor.com/background-agent?bcId=bc-ef306a7e-37b3-475c-acd3-0077cefde640"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ef306a7e-37b3-475c-acd3-0077cefde640"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

