### PR TITLE
Schedule type enum validation

### DIFF
--- a/backend/src/app/db/models.py
+++ b/backend/src/app/db/models.py
@@ -207,7 +207,11 @@ class ActivityPricing(Base):
         nullable=False,
     )
     pricing_type: Mapped[PricingType] = mapped_column(
-        sa.Enum(PricingType, name="pricing_type"),
+        sa.Enum(
+            PricingType,
+            name="pricing_type",
+            values_callable=lambda x: [e.value for e in x],
+        ),
         nullable=False,
     )
     amount: Mapped[Decimal] = mapped_column(Numeric(10, 2), nullable=False)
@@ -247,7 +251,11 @@ class ActivitySchedule(Base):
         nullable=False,
     )
     schedule_type: Mapped[ScheduleType] = mapped_column(
-        sa.Enum(ScheduleType, name="schedule_type"),
+        sa.Enum(
+            ScheduleType,
+            name="schedule_type",
+            values_callable=lambda x: [e.value for e in x],
+        ),
         nullable=False,
     )
     day_of_week_utc: Mapped[Optional[int]] = mapped_column(


### PR DESCRIPTION
Fix `LookupError` for enum values by configuring SQLAlchemy to use lowercase enum values from the database.

The `LookupError` occurred because SQLAlchemy's default `sa.Enum` mapping uses Python enum member names (e.g., `WEEKLY`), while the PostgreSQL enum was created with lowercase values (e.g., `'weekly'`). Adding `values_callable` ensures SQLAlchemy correctly maps the lowercase database values to the Python enum.

---
<a href="https://cursor.com/background-agent?bcId=bc-9326abfe-b215-4300-afcf-a2dbaf428225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9326abfe-b215-4300-afcf-a2dbaf428225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

