### PR TITLE
feat(admin-web): add owner selection for organizations

### DIFF
--- a/apps/admin_web/next-env.d.ts
+++ b/apps/admin_web/next-env.d.ts
@@ -1,4 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
 
-// NOTE: This file should not be edited.
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/admin_web/src/lib/api-client.ts
+++ b/apps/admin_web/src/lib/api-client.ts
@@ -30,6 +30,11 @@ export interface OrganizationPictureDeleteRequest {
   object_key?: string;
 }
 
+export interface CognitoUsersResponse {
+  items: import('../types/admin').CognitoUser[];
+  pagination_token?: string | null;
+}
+
 export class ApiError extends Error {
   status: number;
   detail?: string;
@@ -172,4 +177,22 @@ export async function deleteOrganizationPicture(
     },
     body: JSON.stringify(payload),
   });
+}
+
+function buildCognitoUsersUrl() {
+  const base = getApiBaseUrl();
+  const normalized = base.endsWith('/') ? base : `${base}/`;
+  return new URL('v1/admin/cognito-users', normalized).toString();
+}
+
+export async function listCognitoUsers(
+  paginationToken?: string,
+  limit = 50
+): Promise<CognitoUsersResponse> {
+  const url = new URL(buildCognitoUsersUrl());
+  url.searchParams.set('limit', `${limit}`);
+  if (paginationToken) {
+    url.searchParams.set('pagination_token', paginationToken);
+  }
+  return request<CognitoUsersResponse>(url.toString());
 }

--- a/apps/admin_web/src/types/admin.ts
+++ b/apps/admin_web/src/types/admin.ts
@@ -2,9 +2,24 @@ export interface Organization {
   id: string;
   name: string;
   description?: string | null;
+  owner_id: string;
   picture_urls?: string[];
   created_at?: string;
   updated_at?: string;
+}
+
+export interface CognitoUser {
+  sub: string;
+  email?: string | null;
+  email_verified?: boolean;
+  name?: string | null;
+  given_name?: string | null;
+  family_name?: string | null;
+  username?: string | null;
+  status?: string | null;
+  enabled?: boolean;
+  created_at?: string | null;
+  updated_at?: string | null;
 }
 
 export interface Location {


### PR DESCRIPTION
- Add CognitoUser type to types/admin.ts
- Add owner_id to Organization interface
- Add listCognitoUsers function to api-client.ts
- Update organizations-panel.tsx:
  - Load Cognito users on mount
  - Add owner dropdown in the form
  - Validate owner selection before save
  - Display owner in the organizations table
  - Include owner_id in create/update payloads

Now admins can select an owner from a dropdown when creating or editing an organization in the admin console.