### PR TITLE
fix: add cognito-users API Gateway route

### DIFF
--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -1366,6 +1366,13 @@ export class ApiStack extends cdk.Stack {
       authorizer,
     });
 
+    // Cognito users listing endpoint (for owner selection)
+    const cognitoUsers = admin.addResource("cognito-users");
+    cognitoUsers.addMethod("GET", adminIntegration, {
+      authorizationType: apigateway.AuthorizationType.COGNITO,
+      authorizer,
+    });
+
     // ---------------------------------------------------------------------
     // Admin Bootstrap (Conditional)
     // ---------------------------------------------------------------------


### PR DESCRIPTION
The GET /admin/cognito-users endpoint was implemented in the Lambda but not registered in API Gateway. This adds the route configuration.