### PR TITLE
fix: grant ListUsers permission to admin Lambda

### DIFF
--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -858,6 +858,7 @@ export class ApiStack extends cdk.Stack {
           "cognito-idp:AdminAddUserToGroup",
           "cognito-idp:AdminRemoveUserFromGroup",
           "cognito-idp:AdminListGroupsForUser",
+          "cognito-idp:ListUsers",
         ],
         resources: [userPool.userPoolArn],
       })


### PR DESCRIPTION
The admin Lambda needs cognito-idp:ListUsers permission to list Cognito users for the owner selection dropdown.