### PR TITLE
refactor: Rename pictures to media across frontend and backend

### DIFF
--- a/apps/admin_web/src/components/admin/admin-dashboard.tsx
+++ b/apps/admin_web/src/components/admin/admin-dashboard.tsx
@@ -9,13 +9,13 @@ import { StatusBanner } from '../status-banner';
 import { ActivitiesPanel } from './activities-panel';
 import { LocationsPanel } from './locations-panel';
 import { OrganizationsPanel } from './organizations-panel';
-import { PicturesPanel } from './pictures-panel';
+import { MediaPanel } from './media-panel';
 import { PricingPanel } from './pricing-panel';
 import { SchedulesPanel } from './schedules-panel';
 
 const sectionLabels = [
   { key: 'organizations', label: 'Organizations' },
-  { key: 'pictures', label: 'Pictures' },
+  { key: 'media', label: 'Media' },
   { key: 'locations', label: 'Locations' },
   { key: 'activities', label: 'Activities' },
   { key: 'pricing', label: 'Pricing' },
@@ -28,8 +28,8 @@ export function AdminDashboard() {
 
   const activeContent = useMemo(() => {
     switch (activeSection) {
-      case 'pictures':
-        return <PicturesPanel />;
+      case 'media':
+        return <MediaPanel />;
       case 'locations':
         return <LocationsPanel />;
       case 'activities':

--- a/apps/admin_web/src/components/admin/organizations-panel.tsx
+++ b/apps/admin_web/src/components/admin/organizations-panel.tsx
@@ -129,30 +129,30 @@ export function OrganizationsPanel() {
         owner_id: formState.owner_id,
       };
       if (editingId) {
-        // Preserve existing picture_urls when updating
+        // Preserve existing media_urls when updating
         const existingOrg = items.find((item) => item.id === editingId);
-        const payloadWithPictures = {
+        const payloadWithMedia = {
           ...payload,
-          picture_urls: existingOrg?.picture_urls ?? [],
+          media_urls: existingOrg?.media_urls ?? [],
         };
         const updated = await updateResource<
-          typeof payloadWithPictures,
+          typeof payloadWithMedia,
           Organization
-        >('organizations', editingId, payloadWithPictures);
+        >('organizations', editingId, payloadWithMedia);
         setItems((prev) =>
           prev.map((item) =>
             item.id === editingId ? updated : item
           )
         );
       } else {
-        const payloadWithPictures = {
+        const payloadWithMedia = {
           ...payload,
-          picture_urls: [],
+          media_urls: [],
         };
         const created = await createResource<
-          typeof payloadWithPictures,
+          typeof payloadWithMedia,
           Organization
-        >('organizations', payloadWithPictures);
+        >('organizations', payloadWithMedia);
         setItems((prev) => [created, ...prev]);
       }
       resetForm();
@@ -205,7 +205,7 @@ export function OrganizationsPanel() {
     <div className='space-y-6'>
       <Card
         title='Organizations'
-        description='Create and manage organizations. Use the Pictures section to add images.'
+        description='Create and manage organizations. Use the Media section to add images.'
       >
         {error && (
           <div className='mb-4'>

--- a/apps/admin_web/src/lib/api-client.ts
+++ b/apps/admin_web/src/lib/api-client.ts
@@ -13,20 +13,20 @@ export interface ListResponse<T> {
   next_cursor?: string | null;
 }
 
-export interface OrganizationPictureUploadRequest {
+export interface OrganizationMediaUploadRequest {
   file_name: string;
   content_type: string;
 }
 
-export interface OrganizationPictureUploadResponse {
+export interface OrganizationMediaUploadResponse {
   upload_url: string;
-  picture_url: string;
+  media_url: string;
   object_key: string;
   expires_in: number;
 }
 
-export interface OrganizationPictureDeleteRequest {
-  picture_url?: string;
+export interface OrganizationMediaDeleteRequest {
+  media_url?: string;
   object_key?: string;
 }
 
@@ -53,10 +53,10 @@ function buildResourceUrl(resource: ResourceName, id?: string) {
   return new URL(suffix, normalized).toString();
 }
 
-function buildOrganizationPictureUrl(organizationId: string) {
+function buildOrganizationMediaUrl(organizationId: string) {
   const base = getApiBaseUrl();
   const normalized = base.endsWith('/') ? base : `${base}/`;
-  const suffix = `v1/admin/organizations/${organizationId}/pictures`;
+  const suffix = `v1/admin/organizations/${organizationId}/media`;
   return new URL(suffix, normalized).toString();
 }
 
@@ -150,12 +150,12 @@ export async function deleteResource(resource: ResourceName, id: string) {
   });
 }
 
-export async function createOrganizationPictureUpload(
+export async function createOrganizationMediaUpload(
   organizationId: string,
-  payload: OrganizationPictureUploadRequest
+  payload: OrganizationMediaUploadRequest
 ) {
-  return request<OrganizationPictureUploadResponse>(
-    buildOrganizationPictureUrl(organizationId),
+  return request<OrganizationMediaUploadResponse>(
+    buildOrganizationMediaUrl(organizationId),
     {
       method: 'POST',
       headers: {
@@ -166,11 +166,11 @@ export async function createOrganizationPictureUpload(
   );
 }
 
-export async function deleteOrganizationPicture(
+export async function deleteOrganizationMedia(
   organizationId: string,
-  payload: OrganizationPictureDeleteRequest
+  payload: OrganizationMediaDeleteRequest
 ) {
-  return request<void>(buildOrganizationPictureUrl(organizationId), {
+  return request<void>(buildOrganizationMediaUrl(organizationId), {
     method: 'DELETE',
     headers: {
       'Content-Type': 'application/json',

--- a/apps/admin_web/src/types/admin.ts
+++ b/apps/admin_web/src/types/admin.ts
@@ -3,7 +3,7 @@ export interface Organization {
   name: string;
   description?: string | null;
   owner_id: string;
-  picture_urls?: string[];
+  media_urls?: string[];
   created_at?: string;
   updated_at?: string;
 }

--- a/backend/db/alembic/versions/0006_rename_picture_urls_to_media_urls.py
+++ b/backend/db/alembic/versions/0006_rename_picture_urls_to_media_urls.py
@@ -1,0 +1,29 @@
+"""Rename picture_urls to media_urls in organizations table."""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "0006_rename_picture_urls_to_media_urls"
+down_revision: Union[str, None] = "0005_add_organization_owner"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Rename picture_urls column to media_urls."""
+    op.alter_column(
+        "organizations",
+        "picture_urls",
+        new_column_name="media_urls",
+    )
+
+
+def downgrade() -> None:
+    """Rename media_urls column back to picture_urls."""
+    op.alter_column(
+        "organizations",
+        "media_urls",
+        new_column_name="picture_urls",
+    )

--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -842,8 +842,8 @@ export class ApiStack extends cdk.Stack {
         DATABASE_IAM_AUTH: "true",
         ADMIN_GROUP: adminGroupName,
         COGNITO_USER_POOL_ID: userPool.userPoolId,
-        ORGANIZATION_PICTURES_BUCKET: organizationImagesBucket.bucketName,
-        ORGANIZATION_PICTURES_BASE_URL:
+        ORGANIZATION_MEDIA_BUCKET: organizationImagesBucket.bucketName,
+        ORGANIZATION_MEDIA_BASE_URL:
           `https://${organizationImagesBucket.bucketRegionalDomainName}`,
         CORS_ALLOWED_ORIGINS: corsAllowedOrigins.join(","),
       },
@@ -1343,12 +1343,12 @@ export class ApiStack extends cdk.Stack {
       });
 
       if (resourceName === "organizations") {
-        const pictures = resourceById.addResource("pictures");
-        pictures.addMethod("POST", adminIntegration, {
+        const media = resourceById.addResource("media");
+        media.addMethod("POST", adminIntegration, {
           authorizationType: apigateway.AuthorizationType.COGNITO,
           authorizer,
         });
-        pictures.addMethod("DELETE", adminIntegration, {
+        media.addMethod("DELETE", adminIntegration, {
           authorizationType: apigateway.AuthorizationType.COGNITO,
           authorizer,
         });

--- a/backend/src/app/api/activities_search.py
+++ b/backend/src/app/api/activities_search.py
@@ -154,7 +154,7 @@ def map_row_to_result(row: Any) -> ActivitySearchResultSchema:
             name=organization.name,
             description=organization.description,
             owner_id=organization.owner_id,
-            picture_urls=organization.picture_urls or [],
+            media_urls=organization.media_urls or [],
         ),
         location=LocationSchema(
             id=str(location.id),

--- a/backend/src/app/api/schemas.py
+++ b/backend/src/app/api/schemas.py
@@ -20,7 +20,7 @@ class OrganizationSchema(BaseModel):
     name: str
     description: Optional[str]
     owner_id: str
-    picture_urls: List[str]
+    media_urls: List[str]
 
 
 class LocationSchema(BaseModel):

--- a/backend/src/app/db/models.py
+++ b/backend/src/app/db/models.py
@@ -60,7 +60,7 @@ class Organization(Base):
         nullable=False,
         comment="Cognito user sub (subject) identifier of the organization owner",
     )
-    picture_urls: Mapped[List[str]] = mapped_column(
+    media_urls: Mapped[List[str]] = mapped_column(
         ARRAY(Text()),
         nullable=False,
         server_default=text("'{}'::text[]"),

--- a/backend/src/app/db/repositories/organization.py
+++ b/backend/src/app/db/repositories/organization.py
@@ -100,14 +100,14 @@ def _escape_like_pattern(pattern: str) -> str:
         self,
         name: str,
         description: Optional[str] = None,
-        picture_urls: Optional[Sequence[str]] = None,
+        media_urls: Optional[Sequence[str]] = None,
     ) -> Organization:
         """Create a new organization.
 
         Args:
             name: Organization name.
             description: Optional description.
-            picture_urls: Optional list of picture URLs.
+            media_urls: Optional list of media URLs.
 
         Returns:
             The created organization.
@@ -115,7 +115,7 @@ def _escape_like_pattern(pattern: str) -> str:
         org = Organization(
             name=name,
             description=description,
-            picture_urls=list(picture_urls or []),
+            media_urls=list(media_urls or []),
         )
         return self.create(org)
 
@@ -124,7 +124,7 @@ def _escape_like_pattern(pattern: str) -> str:
         organization: Organization,
         name: Optional[str] = None,
         description: Optional[str] = None,
-        picture_urls: Optional[Sequence[str]] = None,
+        media_urls: Optional[Sequence[str]] = None,
     ) -> Organization:
         """Update an organization.
 
@@ -132,7 +132,7 @@ def _escape_like_pattern(pattern: str) -> str:
             organization: The organization to update.
             name: New name (if provided).
             description: New description (if provided).
-            picture_urls: New picture URLs (if provided).
+            media_urls: New media URLs (if provided).
 
         Returns:
             The updated organization.
@@ -141,6 +141,6 @@ def _escape_like_pattern(pattern: str) -> str:
             organization.name = name
         if description is not None:
             organization.description = description
-        if picture_urls is not None:
-            organization.picture_urls = list(picture_urls)
+        if media_urls is not None:
+            organization.media_urls = list(media_urls)
         return self.update(organization)

--- a/tests/test_admin_security_validation.py
+++ b/tests/test_admin_security_validation.py
@@ -13,14 +13,14 @@ from app.api.admin import (  # noqa: E402
     _validate_currency,
     _validate_language_code,
     _validate_languages,
-    _validate_picture_urls,
+    _validate_media_urls,
     _validate_string_length,
     _validate_url,
     MAX_NAME_LENGTH,
     MAX_DESCRIPTION_LENGTH,
     MAX_URL_LENGTH,
     MAX_LANGUAGES_COUNT,
-    MAX_PICTURE_URLS_COUNT,
+    MAX_MEDIA_URLS_COUNT,
 )
 from app.exceptions import ValidationError  # noqa: E402
 
@@ -127,8 +127,8 @@ class TestValidateUrl:
         assert f"must be at most {MAX_URL_LENGTH}" in str(exc_info.value)
 
 
-class TestValidatePictureUrls:
-    """Tests for picture URLs validation."""
+class TestValidateMediaUrls:
+    """Tests for media URLs validation."""
 
     def test_valid_urls(self) -> None:
         """Valid URLs should pass."""
@@ -136,20 +136,20 @@ class TestValidatePictureUrls:
             "https://example.com/image1.png",
             "https://example.com/image2.jpg",
         ]
-        result = _validate_picture_urls(urls)
+        result = _validate_media_urls(urls)
         assert len(result) == 2
 
     def test_empty_list(self) -> None:
         """Empty list should pass."""
-        result = _validate_picture_urls([])
+        result = _validate_media_urls([])
         assert result == []
 
     def test_too_many_urls(self) -> None:
         """Too many URLs should raise error."""
         urls = [f"https://example.com/img{i}.png" for i in range(25)]
         with pytest.raises(ValidationError) as exc_info:
-            _validate_picture_urls(urls)
-        assert f"cannot have more than {MAX_PICTURE_URLS_COUNT}" in str(exc_info.value)
+            _validate_media_urls(urls)
+        assert f"cannot have more than {MAX_MEDIA_URLS_COUNT}" in str(exc_info.value)
 
     def test_invalid_url_in_list(self) -> None:
         """Invalid URL in list should raise error."""
@@ -158,13 +158,13 @@ class TestValidatePictureUrls:
             "javascript:alert(1)",
         ]
         with pytest.raises(ValidationError) as exc_info:
-            _validate_picture_urls(urls)
+            _validate_media_urls(urls)
         assert "must use http or https scheme" in str(exc_info.value)
 
     def test_empty_strings_filtered(self) -> None:
         """Empty strings should be filtered out."""
         urls = ["https://example.com/image.png", "", "  "]
-        result = _validate_picture_urls(urls)
+        result = _validate_media_urls(urls)
         assert len(result) == 1
 
 

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -64,20 +64,20 @@ class TestOrganizationRepository:
         assert org.name == 'Test Org'
         assert org.description == 'Test Description'
 
-    def test_create_organization_with_picture_urls(self, db_session) -> None:
-        """Should store organization picture URLs."""
+    def test_create_organization_with_media_urls(self, db_session) -> None:
+        """Should store organization media URLs."""
         from app.db.repositories.organization import OrganizationRepository
 
         repo = OrganizationRepository(db_session)
         org = repo.create_organization(
             name='Test Org',
-            picture_urls=[
+            media_urls=[
                 'https://example.com/pic-1.jpg',
                 'https://example.com/pic-2.jpg',
             ],
         )
 
-        assert org.picture_urls == [
+        assert org.media_urls == [
             'https://example.com/pic-1.jpg',
             'https://example.com/pic-2.jpg',
         ]


### PR DESCRIPTION
Frontend changes:
- Rename pictures-panel.tsx to media-panel.tsx
- Update navigation label from 'Pictures' to 'Media'
- Rename all picture-related functions and variables to media
- Update API client interfaces and functions
- Update Organization type to use media_urls

Backend changes:
- Create migration 0006 to rename picture_urls to media_urls column
- Update Organization model to use media_urls
- Update API endpoint from /pictures to /media
- Rename environment variables from ORGANIZATION_PICTURES_* to ORGANIZATION_MEDIA_*
- Update all handlers, validators, and serializers
- Update schemas for activity search

Test updates:
- Update test imports and test class names
- Update test assertions for media_urls