### PR TITLE
fix: Shorten migration revision name to fit 32 char limit

### DIFF
--- a/backend/db/alembic/versions/0006_rename_to_media_urls.py
+++ b/backend/db/alembic/versions/0006_rename_to_media_urls.py
@@ -5,7 +5,7 @@ from typing import Sequence, Union
 from alembic import op
 
 
-revision: str = "0006_rename_picture_urls_to_media_urls"
+revision: str = "0006_rename_to_media_urls"
 down_revision: Union[str, None] = "0005_add_organization_owner"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None


### PR DESCRIPTION
The alembic_version table has a varchar(32) column for version_num. Shortened '0006_rename_picture_urls_to_media_urls' (40 chars) to '0006_rename_to_media_urls' (25 chars).