### PR TITLE
fix(migration): use postgresql.ENUM to prevent auto-type creation

### DIFF
--- a/backend/db/alembic/versions/0007_add_organization_access_requests.py
+++ b/backend/db/alembic/versions/0007_add_organization_access_requests.py
@@ -11,6 +11,7 @@ from typing import Union
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import UUID
 
 revision: str = "0007_add_organization_access_requests"
@@ -83,7 +84,7 @@ def upgrade() -> None:
         ),
         sa.Column(
             "status",
-            sa.Enum(
+            postgresql.ENUM(
                 "pending",
                 "approved",
                 "rejected",


### PR DESCRIPTION
The sa.Enum type in Alembic may still emit CREATE TYPE despite create_type=False in certain conditions. Using postgresql.ENUM directly with create_type=False is more reliable for PostgreSQL databases and ensures the type is not auto-created.

This combined with the existing DO block IF NOT EXISTS check provides robust handling of the enum type creation.