### PR TITLE
fix(migration): shorten 0008 revision ID to fit varchar(32)

### DIFF
--- a/backend/db/alembic/versions/0008_access_req_ticket_id.py
+++ b/backend/db/alembic/versions/0008_access_req_ticket_id.py
@@ -12,7 +12,7 @@ from typing import Union
 from alembic import op
 import sqlalchemy as sa
 
-revision: str = "0008_add_ticket_id_to_access_requests"
+revision: str = "0008_access_req_ticket_id"
 down_revision: Union[str, None] = "0007_org_access_requests"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None


### PR DESCRIPTION
Renamed 0008_add_ticket_id_to_access_requests (37 chars) to 0008_access_req_ticket_id (25 chars).