### PR TITLE
Admin cognito user roles

### DIFF
--- a/apps/admin_web/src/components/admin/admin-dashboard.tsx
+++ b/apps/admin_web/src/components/admin/admin-dashboard.tsx
@@ -14,6 +14,7 @@ import {
   SchedulesPanel,
 } from '../shared';
 import { AccessRequestsPanel } from './access-requests-panel';
+import { CognitoUsersPanel } from './cognito-users-panel';
 import { MediaPanel } from './media-panel';
 import { OwnerDashboard } from './owner-dashboard';
 
@@ -24,7 +25,8 @@ const sectionLabels = [
   { key: 'activities', label: 'Activities' },
   { key: 'pricing', label: 'Pricing' },
   { key: 'schedules', label: 'Schedules' },
-  { key: 'access-requests', label: 'Access Requests' },
+  { key: 'access-requests', label: 'Access Requests', dividerBefore: true },
+  { key: 'cognito-users', label: 'Cognito Users' },
 ];
 
 export function AdminDashboard() {
@@ -45,6 +47,8 @@ export function AdminDashboard() {
         return <SchedulesPanel mode='admin' />;
       case 'access-requests':
         return <AccessRequestsPanel />;
+      case 'cognito-users':
+        return <CognitoUsersPanel />;
       case 'organizations':
       default:
         return <OrganizationsPanel mode='admin' />;

--- a/apps/admin_web/src/components/admin/cognito-users-panel.tsx
+++ b/apps/admin_web/src/components/admin/cognito-users-panel.tsx
@@ -1,0 +1,287 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import {
+  ApiError,
+  listCognitoUsers,
+  addUserToGroup,
+  removeUserFromGroup,
+  type CognitoUsersResponse,
+} from '../../lib/api-client';
+import type { CognitoUser } from '../../types/admin';
+import { useAuth } from '../auth-provider';
+import { Button } from '../ui/button';
+import { Card } from '../ui/card';
+import { StatusBanner } from '../status-banner';
+
+function RoleBadge({
+  role,
+  isActive,
+}: {
+  role: 'admin' | 'owner';
+  isActive: boolean;
+}) {
+  const colors = isActive
+    ? role === 'admin'
+      ? 'bg-purple-100 text-purple-800'
+      : 'bg-blue-100 text-blue-800'
+    : 'bg-slate-100 text-slate-400';
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${colors}`}
+    >
+      {role.charAt(0).toUpperCase() + role.slice(1)}
+    </span>
+  );
+}
+
+function UserStatusBadge({ status }: { status: string | null | undefined }) {
+  const statusColors: Record<string, string> = {
+    CONFIRMED: 'bg-green-100 text-green-800',
+    UNCONFIRMED: 'bg-yellow-100 text-yellow-800',
+    FORCE_CHANGE_PASSWORD: 'bg-orange-100 text-orange-800',
+    DISABLED: 'bg-red-100 text-red-800',
+  };
+
+  const color = status ? statusColors[status] || 'bg-slate-100 text-slate-600' : 'bg-slate-100 text-slate-600';
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${color}`}
+    >
+      {status || 'Unknown'}
+    </span>
+  );
+}
+
+export function CognitoUsersPanel() {
+  const { user: currentUser } = useAuth();
+  const [users, setUsers] = useState<CognitoUser[]>([]);
+  const [paginationToken, setPaginationToken] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+  const [actionError, setActionError] = useState('');
+
+  const loadUsers = async (token?: string, reset = false) => {
+    setIsLoading(true);
+    setError('');
+    try {
+      const response: CognitoUsersResponse = await listCognitoUsers(token, 50);
+      setUsers((prev) =>
+        reset || !token ? response.items : [...prev, ...response.items]
+      );
+      setPaginationToken(response.pagination_token ?? null);
+    } catch (err) {
+      const message =
+        err instanceof ApiError
+          ? err.message
+          : 'Failed to load Cognito users.';
+      setError(message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadUsers(undefined, true);
+  }, []);
+
+  const handleToggleRole = async (
+    targetUser: CognitoUser,
+    role: 'admin' | 'owner',
+    currentlyHasRole: boolean
+  ) => {
+    if (!targetUser.username) {
+      setActionError('User has no username');
+      return;
+    }
+
+    const actionKey = `${targetUser.sub}-${role}`;
+    setActionLoading(actionKey);
+    setActionError('');
+
+    try {
+      if (currentlyHasRole) {
+        await removeUserFromGroup(targetUser.username, role);
+      } else {
+        await addUserToGroup(targetUser.username, role);
+      }
+
+      // Update the local state
+      setUsers((prev) =>
+        prev.map((u) => {
+          if (u.sub === targetUser.sub) {
+            const newGroups = currentlyHasRole
+              ? (u.groups || []).filter((g) => g !== role)
+              : [...(u.groups || []), role];
+            return { ...u, groups: newGroups };
+          }
+          return u;
+        })
+      );
+    } catch (err) {
+      const message =
+        err instanceof ApiError
+          ? err.message
+          : `Failed to ${currentlyHasRole ? 'remove' : 'add'} ${role} role.`;
+      setActionError(message);
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const isCurrentUser = (cognitoUser: CognitoUser) => {
+    // Compare by subject (Cognito subject identifier)
+    return currentUser?.subject === cognitoUser.sub;
+  };
+
+  const formatDate = (dateStr: string | null | undefined) => {
+    if (!dateStr) return '-';
+    return new Date(dateStr).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  };
+
+  return (
+    <div className='space-y-6'>
+      <Card
+        title='Cognito Users'
+        description='Manage user roles across all identity providers (Google, Apple, Microsoft). Promote or demote users to Admin or Owner roles.'
+      >
+        {error && (
+          <div className='mb-4'>
+            <StatusBanner variant='error' title='Error'>
+              {error}
+            </StatusBanner>
+          </div>
+        )}
+
+        {actionError && (
+          <div className='mb-4'>
+            <StatusBanner variant='error' title='Action Failed'>
+              {actionError}
+            </StatusBanner>
+          </div>
+        )}
+
+        {isLoading && users.length === 0 ? (
+          <p className='text-sm text-slate-600'>Loading users...</p>
+        ) : users.length === 0 ? (
+          <p className='text-sm text-slate-600'>No users found.</p>
+        ) : (
+          <div className='overflow-x-auto'>
+            <table className='w-full text-left text-sm'>
+              <thead className='border-b border-slate-200 text-slate-500'>
+                <tr>
+                  <th className='py-2'>Email</th>
+                  <th className='py-2'>Status</th>
+                  <th className='py-2'>Roles</th>
+                  <th className='py-2'>Created</th>
+                  <th className='py-2 text-right'>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {users.map((cognitoUser) => {
+                  const hasAdminRole = cognitoUser.groups?.includes('admin') || false;
+                  const hasOwnerRole = cognitoUser.groups?.includes('owner') || false;
+                  const isCurrent = isCurrentUser(cognitoUser);
+
+                  return (
+                    <tr key={cognitoUser.sub} className='border-b border-slate-100'>
+                      <td className='py-2'>
+                        <div className='flex items-center gap-2'>
+                          <span className='font-medium'>
+                            {cognitoUser.email || cognitoUser.username || 'Unknown'}
+                          </span>
+                          {isCurrent && (
+                            <span className='rounded bg-slate-200 px-1.5 py-0.5 text-xs text-slate-600'>
+                              You
+                            </span>
+                          )}
+                        </div>
+                        {cognitoUser.name && (
+                          <div className='text-xs text-slate-500'>
+                            {cognitoUser.name}
+                          </div>
+                        )}
+                      </td>
+                      <td className='py-2'>
+                        <UserStatusBadge status={cognitoUser.status} />
+                      </td>
+                      <td className='py-2'>
+                        <div className='flex gap-1'>
+                          <RoleBadge role='admin' isActive={hasAdminRole} />
+                          <RoleBadge role='owner' isActive={hasOwnerRole} />
+                        </div>
+                      </td>
+                      <td className='py-2 text-slate-600'>
+                        {formatDate(cognitoUser.created_at)}
+                      </td>
+                      <td className='py-2 text-right'>
+                        {isCurrent ? (
+                          <span className='text-xs text-slate-400'>
+                            Cannot modify your own roles
+                          </span>
+                        ) : (
+                          <div className='flex justify-end gap-2'>
+                            <Button
+                              type='button'
+                              size='sm'
+                              variant={hasAdminRole ? 'danger' : 'secondary'}
+                              onClick={() =>
+                                handleToggleRole(cognitoUser, 'admin', hasAdminRole)
+                              }
+                              disabled={actionLoading === `${cognitoUser.sub}-admin`}
+                            >
+                              {actionLoading === `${cognitoUser.sub}-admin`
+                                ? '...'
+                                : hasAdminRole
+                                  ? 'Remove Admin'
+                                  : 'Make Admin'}
+                            </Button>
+                            <Button
+                              type='button'
+                              size='sm'
+                              variant={hasOwnerRole ? 'danger' : 'secondary'}
+                              onClick={() =>
+                                handleToggleRole(cognitoUser, 'owner', hasOwnerRole)
+                              }
+                              disabled={actionLoading === `${cognitoUser.sub}-owner`}
+                            >
+                              {actionLoading === `${cognitoUser.sub}-owner`
+                                ? '...'
+                                : hasOwnerRole
+                                  ? 'Remove Owner'
+                                  : 'Make Owner'}
+                            </Button>
+                          </div>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+            {paginationToken && (
+              <div className='mt-4'>
+                <Button
+                  type='button'
+                  variant='secondary'
+                  onClick={() => loadUsers(paginationToken)}
+                  disabled={isLoading}
+                >
+                  {isLoading ? 'Loading...' : 'Load more'}
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/apps/admin_web/src/components/app-shell.tsx
+++ b/apps/admin_web/src/components/app-shell.tsx
@@ -7,6 +7,7 @@ import { Button } from './ui/button';
 export interface NavSection {
   key: string;
   label: string;
+  dividerBefore?: boolean;
 }
 
 export interface AppShellProps {
@@ -56,18 +57,22 @@ export function AppShell({
             {sections.map((section) => {
               const isActive = section.key === activeKey;
               return (
-                <button
-                  key={section.key}
-                  type='button'
-                  onClick={() => onSelect(section.key)}
-                  className={`w-full rounded-md px-3 py-2 text-left text-sm ${
-                    isActive
-                      ? 'bg-slate-900 text-white'
-                      : 'text-slate-700 hover:bg-slate-100'
-                  }`}
-                >
-                  {section.label}
-                </button>
+                <div key={section.key}>
+                  {section.dividerBefore && (
+                    <hr className='my-3 border-slate-200' />
+                  )}
+                  <button
+                    type='button'
+                    onClick={() => onSelect(section.key)}
+                    className={`w-full rounded-md px-3 py-2 text-left text-sm ${
+                      isActive
+                        ? 'bg-slate-900 text-white'
+                        : 'text-slate-700 hover:bg-slate-100'
+                    }`}
+                  >
+                    {section.label}
+                  </button>
+                </div>
               );
             })}
           </nav>

--- a/apps/admin_web/src/lib/api-client.ts
+++ b/apps/admin_web/src/lib/api-client.ts
@@ -197,6 +197,49 @@ export async function listCognitoUsers(
   return request<CognitoUsersResponse>(url.toString());
 }
 
+function buildUserGroupsUrl(username: string) {
+  const base = getApiBaseUrl();
+  const normalized = base.endsWith('/') ? base : `${base}/`;
+  return new URL(`v1/admin/users/${encodeURIComponent(username)}/groups`, normalized).toString();
+}
+
+export interface UserGroupResponse {
+  status: 'added' | 'removed';
+  group: string;
+}
+
+/**
+ * Add a user to a Cognito group (promote).
+ */
+export async function addUserToGroup(
+  username: string,
+  group: string
+): Promise<UserGroupResponse> {
+  return request<UserGroupResponse>(buildUserGroupsUrl(username), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ group }),
+  });
+}
+
+/**
+ * Remove a user from a Cognito group (demote).
+ */
+export async function removeUserFromGroup(
+  username: string,
+  group: string
+): Promise<UserGroupResponse> {
+  return request<UserGroupResponse>(buildUserGroupsUrl(username), {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ group }),
+  });
+}
+
 // --- Owner-specific API methods ---
 
 export interface AccessRequest {

--- a/apps/admin_web/src/types/admin.ts
+++ b/apps/admin_web/src/types/admin.ts
@@ -20,6 +20,7 @@ export interface CognitoUser {
   enabled?: boolean;
   created_at?: string | null;
   updated_at?: string | null;
+  groups?: string[];
 }
 
 export interface Location {


### PR DESCRIPTION
Add a divider in admin navigation and a new panel for managing Cognito user roles.

This introduces a dedicated interface for administrators to view and modify user roles (Admin/Owner) across all social identity providers, enhancing control over user permissions.

---
<a href="https://cursor.com/background-agent?bcId=bc-db902945-74ae-4462-9bba-55a105a28bb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-db902945-74ae-4462-9bba-55a105a28bb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

