### PR TITLE
fix: ignore ResourceNotFoundException in Cognito group onUpdate handler

### DIFF
--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -673,6 +673,9 @@ export class ApiStack extends cdk.Stack {
             physicalResourceId: customresources.PhysicalResourceId.of(
               `${userPool.userPoolId}-${group.name}`
             ),
+            // Ignore if group doesn't exist yet (happens during rename when
+            // physical resource ID changes and triggers replacement)
+            ignoreErrorCodesMatching: "ResourceNotFoundException",
           },
           onDelete: {
             service: "CognitoIdentityServiceProvider",


### PR DESCRIPTION
When renaming groups (e.g., owner -> manager), the physical resource ID changes triggering a CloudFormation replacement. The onUpdate handler was failing because it tried to update a group that doesn't exist yet. Adding ignoreErrorCodesMatching allows the replacement flow to proceed correctly.