### PR TITLE
Manager dropdown default

### DIFF
--- a/apps/admin_web/src/components/shared/organizations-panel.tsx
+++ b/apps/admin_web/src/components/shared/organizations-panel.tsx
@@ -6,6 +6,7 @@ import { useResourcePanel } from '../../hooks/use-resource-panel';
 import { ApiError, listCognitoUsers } from '../../lib/api-client';
 import type { ApiMode } from '../../lib/resource-api';
 import type { CognitoUser, Organization } from '../../types/admin';
+import { useAuth } from '../auth-provider';
 import { Button } from '../ui/button';
 import { Card } from '../ui/card';
 import { Input } from '../ui/input';
@@ -85,6 +86,7 @@ interface OrganizationsPanelProps {
 
 export function OrganizationsPanel({ mode }: OrganizationsPanelProps) {
   const isAdmin = mode === 'admin';
+  const { user } = useAuth();
   const panel = useResourcePanel<Organization, OrganizationFormState>(
     'organizations',
     mode,
@@ -205,9 +207,9 @@ export function OrganizationsPanel({ mode }: OrganizationsPanelProps) {
                 }
               />
             </div>
-            {isAdmin && (
-              <div>
-                <Label htmlFor='org-manager'>Manager</Label>
+            <div>
+              <Label htmlFor='org-manager'>Manager</Label>
+              {isAdmin ? (
                 <Select
                   id='org-manager'
                   value={panel.formState.manager_id}
@@ -222,16 +224,26 @@ export function OrganizationsPanel({ mode }: OrganizationsPanelProps) {
                   <option value=''>
                     {isLoadingUsers ? 'Loading users...' : 'Select a manager'}
                   </option>
-                  {cognitoUsers.map((user) => (
-                    <option key={user.sub} value={user.sub}>
-                      {user.email || user.username || user.sub}
-                      {user.name ? ` (${user.name})` : ''}
+                  {cognitoUsers.map((cognitoUser) => (
+                    <option key={cognitoUser.sub} value={cognitoUser.sub}>
+                      {cognitoUser.email || cognitoUser.username || cognitoUser.sub}
+                      {cognitoUser.name ? ` (${cognitoUser.name})` : ''}
                     </option>
                   ))}
                 </Select>
-              </div>
-            )}
-            <div className={isAdmin ? 'md:col-span-2' : ''}>
+              ) : (
+                <Select
+                  id='org-manager'
+                  value={user?.email ?? ''}
+                  disabled
+                >
+                  <option value={user?.email ?? ''}>
+                    {user?.email ?? 'Unknown'}
+                  </option>
+                </Select>
+              )}
+            </div>
+            <div className='md:col-span-2'>
               <Label htmlFor='org-description'>Description</Label>
               <Textarea
                 id='org-description'


### PR DESCRIPTION
Make the manager dropdown visible but disabled for managers in the organization panel, defaulting to their email, to align with the organization dropdown behavior.

The manager dropdown was previously hidden for users in `manager` mode. This change ensures managers can see their assigned manager (themselves) but cannot modify it, providing a consistent UI experience with other disabled fields. The `useAuth` hook is used to retrieve the current user's email, and the grid layout for the description field was adjusted as the manager dropdown is now always present.

---
<a href="https://cursor.com/background-agent?bcId=bc-146698c5-0528-4e3e-858b-1a1fd0319c64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-146698c5-0528-4e3e-858b-1a1fd0319c64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

