### PR TITLE
CloudWatch asset log groups

### DIFF
--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -767,8 +767,8 @@ export class ApiStack extends cdk.Stack {
     });
 
     // Helper to create Lambda functions using the factory
-    // Note: functionName is omitted to let CloudFormation generate unique names
-    // and avoid conflicts with existing Lambda functions.
+    // Function names use the standard prefix for consistent naming and
+    // to ensure log groups follow the /aws/lambda/{functionName} convention.
     const createPythonFunction = (
       id: string,
       props: {
@@ -781,6 +781,7 @@ export class ApiStack extends cdk.Stack {
       }
     ) => {
       const pythonLambda = lambdaFactory.create(id, {
+        functionName: name(id),
         handler: props.handler,
         environment: props.environment,
         timeout: props.timeout,

--- a/backend/infrastructure/lib/constructs/python-lambda.ts
+++ b/backend/infrastructure/lib/constructs/python-lambda.ts
@@ -26,8 +26,8 @@ export function selectPrivateSubnets(_vpc: ec2.IVpc): ec2.SubnetSelection {
  * Properties for the PythonLambda construct.
  */
 export interface PythonLambdaProps {
-  /** Function name (optional - CloudFormation will generate if not provided). */
-  functionName?: string;
+  /** Function name (required for standard /aws/lambda/ log group naming). */
+  functionName: string;
   /** Handler path (e.g., "lambda/handler.lambda_handler"). */
   handler: string;
   /** Optional function description. */
@@ -180,7 +180,9 @@ export class PythonLambda extends Construct {
 
     // Standard 90-day log retention for all Lambda functions
     // SECURITY: Encrypted with KMS key
+    // Use standard /aws/lambda/{functionName} naming convention
     const logGroup = new logs.LogGroup(this, "LogGroup", {
+      logGroupName: `/aws/lambda/${props.functionName}`,
       retention: STANDARD_LOG_RETENTION,
       removalPolicy: cdk.RemovalPolicy.RETAIN,
       encryptionKey: logEncryptionKey,

--- a/docs/architecture/aws-assets-map.md
+++ b/docs/architecture/aws-assets-map.md
@@ -215,9 +215,9 @@ For each function above, the following resources are created:
 | `AdminBootstrapFunction` | Cognito `AdminCreateUser`, `AdminUpdateUserAttributes`, `AdminSetUserPassword`, `AdminAddUserToGroup`, CloudFormation invoke permission |
 
 **Lambda Log Groups:**
-- Created automatically by Lambda service on first invocation
-- Naming: `/aws/lambda/{function-name}`
-- Not explicitly created by CDK
+- Explicitly created by CDK with KMS encryption
+- Naming: `/aws/lambda/{function-name}` (e.g., `/aws/lambda/lxsoftware-siutindei-SiutindeiSearchFunction`)
+- 90-day retention policy
 
 ---
 
@@ -447,7 +447,7 @@ All other resources are deleted when the stack is deleted (unless they are impor
 
 ## Notes
 
-1. **Lambda Log Groups**: Created automatically by AWS Lambda service on first invocation, not by CDK.
+1. **Lambda Log Groups**: Explicitly created by CDK with standard `/aws/lambda/{functionName}` naming and KMS encryption.
 2. **API Gateway Access Log Group**: Must exist before deployment (imported, not created).
 3. **Existing Resources**: The workflow detects and imports existing VPC, database, and security group resources to avoid recreation.
 4. **CDK Bootstrap**: Required once per account/region. The workflow runs `cdk bootstrap` if needed.


### PR DESCRIPTION
Enforce standard `/aws/lambda/` prefix for all Lambda CloudWatch log groups to ensure consistent and predictable naming.

---
<a href="https://cursor.com/background-agent?bcId=bc-18273016-b209-44e4-b4eb-65f17fb58aa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-18273016-b209-44e4-b4eb-65f17fb58aa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

