### PR TITLE
fix: disable IAM authentication on Aurora cluster to fix PAM auth error

### DIFF
--- a/backend/infrastructure/lib/constructs/database.ts
+++ b/backend/infrastructure/lib/constructs/database.ts
@@ -381,7 +381,11 @@ export class DatabaseConstruct extends Construct {
         cloudwatchLogsRetention: STANDARD_LOG_RETENTION,
         credentials: rds.Credentials.fromSecret(dbCredentialsSecret),
         defaultDatabaseName: props.databaseName ?? "siutindei",
-        iamAuthentication: applyImmutableSettings ? true : undefined,
+        // IMPORTANT: iamAuthentication must be false on the cluster to allow
+        // password-based connections for migrations. IAM auth is handled by
+        // RDS Proxy for Lambda app connections. Setting this to true causes
+        // "PAM authentication failed" errors for direct password connections.
+        iamAuthentication: false,
         storageEncrypted: applyImmutableSettings ? true : undefined,
         serverlessV2MinCapacity: props.minCapacity ?? 0.5,
         serverlessV2MaxCapacity: props.maxCapacity ?? 2,


### PR DESCRIPTION
The 'PAM authentication failed for user postgres' error occurs when Aurora expects IAM authentication but receives password credentials.

The migration Lambda connects directly to Aurora with password auth (via Secrets Manager credentials), not through the RDS Proxy.

Architecture:
- Lambda app -> RDS Proxy: IAM authentication (proxy handles this)
- RDS Proxy -> Aurora: Password authentication (via secrets)
- Migration Lambda -> Aurora: Direct password authentication

Setting iamAuthentication: true on the cluster breaks direct password connections. IAM auth should only be on the proxy, not the cluster.

This fix was previously applied in commit 1162d0d but was inadvertently reverted during a refactor.