### PR TITLE
Manager account status error

### DIFF
--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -2004,6 +2004,18 @@ export class ApiStack extends cdk.Stack {
       authorizer: userAuthorizer,
     });
 
+    // Organization suggestion (suggest a new place/organization)
+    // Any logged-in user can suggest places for the platform
+    const userOrgSuggestion = user.addResource("organization-suggestion");
+    userOrgSuggestion.addMethod("GET", adminIntegration, {
+      authorizationType: apigateway.AuthorizationType.CUSTOM,
+      authorizer: userAuthorizer,
+    });
+    userOrgSuggestion.addMethod("POST", adminIntegration, {
+      authorizationType: apigateway.AuthorizationType.CUSTOM,
+      authorizer: userAuthorizer,
+    });
+
     // ---------------------------------------------------------------------
     // Admin Bootstrap (Conditional)
     // ---------------------------------------------------------------------


### PR DESCRIPTION
Add missing API Gateway routes for `/v1/user/organization-suggestion` to resolve "Failed to load your account status" error.

The manager dashboard calls `getUserSuggestions()` which hits `/v1/user/organization-suggestion`. This API Gateway route was missing, causing a 403 error and the overall dashboard load to fail. The backend Lambda handler already supported this route; only the API Gateway definition was missing.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-51b6e965-902d-469f-b1c9-7c80efda5ac5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-51b6e965-902d-469f-b1c9-7c80efda5ac5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

