### PR TITLE
Admin location panel fields

### DIFF
--- a/apps/admin_web/src/components/admin/suggestion-form.tsx
+++ b/apps/admin_web/src/components/admin/suggestion-form.tsx
@@ -168,15 +168,6 @@ export function SuggestionForm({ onSuggestionSubmitted }: SuggestionFormProps) {
         </div>
 
         <div>
-          <Label>Location</Label>
-          <CascadingAreaSelect
-            tree={tree}
-            value={areaId}
-            onChange={handleAreaChange}
-          />
-        </div>
-
-        <div>
           <Label htmlFor='address'>Address</Label>
           <AddressAutocomplete
             id='address'
@@ -186,6 +177,16 @@ export function SuggestionForm({ onSuggestionSubmitted }: SuggestionFormProps) {
             placeholder='Start typing the address...'
             maxLength={500}
             countryCodes={countryCodes}
+          />
+        </div>
+        <div>
+          <Label>Location</Label>
+          <CascadingAreaSelect
+            tree={tree}
+            value={areaId}
+            onChange={handleAreaChange}
+            disableCountry
+            showCountryLast
           />
         </div>
 

--- a/apps/admin_web/src/components/shared/locations-panel.tsx
+++ b/apps/admin_web/src/components/shared/locations-panel.tsx
@@ -237,13 +237,6 @@ export function LocationsPanel({ mode }: LocationsPanelProps) {
             </Select>
           </div>
           <div className='md:col-span-2'>
-            <CascadingAreaSelect
-              tree={tree}
-              value={panel.formState.area_id}
-              onChange={handleAreaChange}
-            />
-          </div>
-          <div className='md:col-span-2'>
             <Label htmlFor='location-address'>Address</Label>
             <AddressAutocomplete
               id='location-address'
@@ -257,6 +250,15 @@ export function LocationsPanel({ mode }: LocationsPanelProps) {
               onSelect={handleAddressSelect}
               placeholder='Start typing an address...'
               countryCodes={countryCodes}
+            />
+          </div>
+          <div className='md:col-span-2'>
+            <CascadingAreaSelect
+              tree={tree}
+              value={panel.formState.area_id}
+              onChange={handleAreaChange}
+              disableCountry
+              showCountryLast
             />
           </div>
           <div>


### PR DESCRIPTION
Reorder location fields to address, then districts, then country, and disable the country dropdown in both the Locations panel and Suggestion form.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-483c85b8-37f0-416b-9485-b626a5062829"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-483c85b8-37f0-416b-9485-b626a5062829"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

