### PR TITLE
Media panel file display

### DIFF
--- a/apps/admin_web/src/components/admin/media-panel.tsx
+++ b/apps/admin_web/src/components/admin/media-panel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { ChangeEvent } from 'react';
 import Image, { type ImageLoaderProps } from 'next/image';
 
@@ -107,6 +107,7 @@ export function MediaPanel({ mode = 'admin' }: MediaPanelProps) {
     []
   );
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const isMediaBusy = isSaving || isProcessingMedia;
 
@@ -460,15 +461,26 @@ export function MediaPanel({ mode = 'admin' }: MediaPanelProps) {
                 <PlusIcon className='h-4 w-4' />
               </Button>
             </div>
-            <div className='flex flex-col gap-2 sm:flex-row'>
-              <Input
+            <div className='flex flex-col gap-2 sm:flex-row sm:items-center'>
+              <input
                 id='media-upload'
+                ref={fileInputRef}
                 type='file'
                 accept='image/*'
                 multiple
                 onChange={handleMediaFiles}
                 disabled={isMediaBusy}
+                className='sr-only'
               />
+              <Button
+                type='button'
+                variant='secondary'
+                onClick={() => fileInputRef.current?.click()}
+                disabled={isMediaBusy}
+                className='w-fit'
+              >
+                Choose files
+              </Button>
               <p className='text-xs text-slate-500 sm:self-center'>
                 Upload files or add URLs. Save to apply changes.
               </p>


### PR DESCRIPTION
Make the "Choose files" button compact and remove the file selection text in the media panel.

The native file input's width was excessive, and the "no files selected" / filename display was redundant as a file preview is shown below.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-462ab4dc-e7bc-44a5-bdf5-dad0083935c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-462ab4dc-e7bc-44a5-bdf5-dad0083935c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

