### PR TITLE
Admin prices thousands separator

### DIFF
--- a/apps/admin_web/src/components/shared/pricing-panel.tsx
+++ b/apps/admin_web/src/components/shared/pricing-panel.tsx
@@ -7,7 +7,10 @@ import currencyCodes from 'currency-codes';
 import { useActivitiesByMode } from '../../hooks/use-activities-by-mode';
 import { useLocationsByMode } from '../../hooks/use-locations-by-mode';
 import { useResourcePanel } from '../../hooks/use-resource-panel';
-import { parseOptionalNumber } from '../../lib/number-parsers';
+import {
+  formatPriceAmount,
+  parseOptionalNumber,
+} from '../../lib/number-parsers';
 import type { ApiMode } from '../../lib/resource-api';
 import type { ActivityPricing } from '../../types/admin';
 import { Button } from '../ui/button';
@@ -142,16 +145,6 @@ export function PricingPanel({ mode }: PricingPanelProps) {
     return normalizeCurrencyCode(value);
   }
 
-  function formatAmount(value: number): string {
-    if (!Number.isFinite(value)) {
-      return String(value);
-    }
-    return new Intl.NumberFormat('en-US', {
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 2,
-    }).format(value);
-  }
-
   function getCurrencySearchText(value?: string | null): string {
     const normalized = normalizeCurrencyCode(value);
     const name = currencyNameByCode.get(normalized);
@@ -243,7 +236,8 @@ export function PricingPanel({ mode }: PricingPanelProps) {
       header: 'Amount',
       render: (item: ActivityPricing) => (
         <span className='text-slate-600'>
-          {getCurrencyDisplay(item.currency)} {formatAmount(item.amount)}
+          {getCurrencyDisplay(item.currency)}{' '}
+          {formatPriceAmount(item.amount)}
         </span>
       ),
     },
@@ -261,11 +255,14 @@ export function PricingPanel({ mode }: PricingPanelProps) {
     const pricingTypeSearch =
       `${pricingTypeLabel} ${item.pricing_type}`.toLowerCase();
     const currencySearch = getCurrencySearchText(item.currency).toLowerCase();
+    const amountSearch = String(item.amount).toLowerCase();
+    const formattedAmountSearch = formatPriceAmount(item.amount).toLowerCase();
     return (
       activityName.toLowerCase().includes(query) ||
       locationName.toLowerCase().includes(query) ||
       pricingTypeSearch.includes(query) ||
-      String(item.amount).toLowerCase().includes(query) ||
+      amountSearch.includes(query) ||
+      formattedAmountSearch.includes(query) ||
       currencySearch.includes(query)
     );
   });

--- a/apps/admin_web/src/lib/number-parsers.ts
+++ b/apps/admin_web/src/lib/number-parsers.ts
@@ -1,5 +1,10 @@
 'use client';
 
+const priceFormatter = new Intl.NumberFormat('en-US', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
 export function parseOptionalNumber(value: string): number | null {
   const trimmed = value.trim();
   if (!trimmed) {
@@ -13,4 +18,31 @@ export function parseRequiredNumber(value: string): number | null {
   const trimmed = value.trim();
   const parsed = Number(trimmed);
   return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function formatPriceAmount(
+  value: number | string | null | undefined
+): string {
+  if (value === null || value === undefined) {
+    return String(value);
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return value;
+    }
+    const normalized = trimmed.replace(/,/g, '');
+    const parsed = Number(normalized);
+    if (!Number.isFinite(parsed)) {
+      return value;
+    }
+    return priceFormatter.format(parsed);
+  }
+
+  if (!Number.isFinite(value)) {
+    return String(value);
+  }
+
+  return priceFormatter.format(value);
 }


### PR DESCRIPTION
Add thousands separators and two decimal places to price amounts in the admin web.

This ensures all displayed prices, including those from string-based API responses, are consistently formatted with `en-US` locale, thousands separators, and two decimal places, improving readability.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-c7fb2a42-e3be-4f90-8ef7-1cd1d9eaa23c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c7fb2a42-e3be-4f90-8ef7-1cd1d9eaa23c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

