### PR TITLE
Cognito user panel last login

### DIFF
--- a/backend/lambda/auth/post_authentication/handler.py
+++ b/backend/lambda/auth/post_authentication/handler.py
@@ -1,0 +1,68 @@
+"""Cognito Post Authentication trigger.
+
+This Lambda updates the user's last login time in a custom attribute.
+
+SECURITY NOTES:
+- Email addresses are masked in logs to comply with privacy regulations
+- Never log tokens or secrets
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+from typing import Mapping
+
+from app.services.aws_proxy import invoke as aws_proxy
+from app.utils.logging import configure_logging
+from app.utils.logging import get_logger
+from app.utils.logging import mask_email
+from app.utils.logging import mask_pii
+
+configure_logging()
+logger = get_logger(__name__)
+
+
+def _mask_user_identifier(event: Mapping[str, Any]) -> str:
+    user_attrs = event.get("request", {}).get("userAttributes", {}) or {}
+    email = user_attrs.get("email") or ""
+    if email:
+        return mask_email(str(email))
+    username = event.get("userName") or ""
+    return mask_pii(str(username))
+
+
+def lambda_handler(event: Mapping[str, Any], _context: Any) -> Mapping[str, Any]:
+    """Set the custom:last_auth_time attribute after successful login."""
+    user_pool_id = event.get("userPoolId")
+    username = event.get("userName")
+    if not user_pool_id or not username:
+        logger.warning("Post-auth event missing user identifiers")
+        return event
+
+    epoch_seconds = str(int(time.time()))
+    masked_user = _mask_user_identifier(event)
+
+    try:
+        aws_proxy(
+            "cognito-idp",
+            "admin_update_user_attributes",
+            {
+                "UserPoolId": user_pool_id,
+                "Username": username,
+                "UserAttributes": [
+                    {
+                        "Name": "custom:last_auth_time",
+                        "Value": epoch_seconds,
+                    }
+                ],
+            },
+        )
+        logger.info(f"Updated last login time for {masked_user}")
+    except Exception as exc:
+        logger.warning(
+            "Failed to update last login time",
+            extra={"user": masked_user, "error": type(exc).__name__},
+        )
+
+    return event

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -68,6 +68,12 @@ their primary responsibilities.
 - Trigger: Cognito User Pool VERIFY_AUTH_CHALLENGE_RESPONSE
 - Purpose: validate passwordless challenge response
 
+### Post authentication
+- Function: AuthPostAuthFunction
+- Handler: backend/lambda/auth/post_authentication/handler.py
+- Trigger: Cognito User Pool POST_AUTHENTICATION
+- Purpose: update `custom:last_auth_time` after successful login
+
 ### Device attestation authorizer
 - Function: DeviceAttestationAuthorizer
 - Handler: backend/lambda/authorizers/device_attestation/handler.py


### PR DESCRIPTION
Enable 'Last Login' display in the Cognito user panel by adding a custom attribute and PostAuthentication trigger.

The "Last Login" field was not working because the `custom:last_auth_time` attribute was not defined or updated during the authentication flow. This change introduces the necessary custom attribute and a PostAuthentication Lambda trigger to populate it for all login types, including social logins.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-97d7651b-5c67-4be1-8da2-30c03ae41413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-97d7651b-5c67-4be1-8da2-30c03ae41413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

