### PR TITLE
Session page day dropdown

### DIFF
--- a/apps/admin_web/src/components/shared/schedules-panel.tsx
+++ b/apps/admin_web/src/components/shared/schedules-panel.tsx
@@ -52,6 +52,16 @@ const scheduleOptions = [
   { value: 'date_specific', label: 'Date specific' },
 ];
 
+const dayOfWeekOptions = [
+  { value: '0', label: 'Sunday' },
+  { value: '1', label: 'Monday' },
+  { value: '2', label: 'Tuesday' },
+  { value: '3', label: 'Wednesday' },
+  { value: '4', label: 'Thursday' },
+  { value: '5', label: 'Friday' },
+  { value: '6', label: 'Saturday' },
+];
+
 function toUtcInputValue(value?: string | null): string {
   if (!value) return '';
   const date = new Date(value);
@@ -372,12 +382,9 @@ export function SchedulesPanel({ mode }: SchedulesPanelProps) {
           {scheduleType === 'weekly' && (
             <>
               <div>
-                <Label htmlFor='schedule-day'>Day of Week (0-6)</Label>
-                <Input
+                <Label htmlFor='schedule-day'>Day of Week (UTC)</Label>
+                <Select
                   id='schedule-day'
-                  type='number'
-                  min='0'
-                  max='6'
                   value={panel.formState.day_of_week_utc}
                   onChange={(e) =>
                     panel.setFormState((prev) => ({
@@ -385,7 +392,14 @@ export function SchedulesPanel({ mode }: SchedulesPanelProps) {
                       day_of_week_utc: e.target.value,
                     }))
                   }
-                />
+                >
+                  <option value=''>Select day</option>
+                  {dayOfWeekOptions.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </Select>
               </div>
               <div>
                 <Label htmlFor='schedule-start'>Start Minutes (UTC)</Label>


### PR DESCRIPTION
Replace the 'Day of Week' free-form input with a Sunday-Saturday dropdown to improve user experience.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-6bd84952-af4b-4ac0-a8aa-b2c548d667e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6bd84952-af4b-4ac0-a8aa-b2c548d667e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

