### PR TITLE
Country flag size

### DIFF
--- a/apps/admin_web/src/components/shared/schedules-panel.tsx
+++ b/apps/admin_web/src/components/shared/schedules-panel.tsx
@@ -834,7 +834,7 @@ export function SchedulesPanel({ mode }: SchedulesPanelProps) {
                       key={option.code}
                       type='button'
                       onClick={() => toggleLanguage(option.code)}
-                      className={`relative flex items-center justify-center rounded border px-1.5 py-1 transition ${
+                      className={`relative flex items-center justify-center rounded border px-1 py-0.5 transition ${
                         isSelected
                           ? 'border-slate-400 bg-slate-50 ring-2 ring-slate-200'
                           : 'border-slate-200 hover:border-slate-300'
@@ -847,8 +847,8 @@ export function SchedulesPanel({ mode }: SchedulesPanelProps) {
                       <img
                         src={option.flagSrc}
                         alt={`${option.label} flag`}
-                        width={24}
-                        height={16}
+                        width={20}
+                        height={14}
                         loading='lazy'
                       />
                     </button>

--- a/apps/admin_web/src/components/ui/language-toggle-input.tsx
+++ b/apps/admin_web/src/components/ui/language-toggle-input.tsx
@@ -71,7 +71,7 @@ export function LanguageToggleInput({
                 key={option.code}
                 type='button'
                 onClick={() => setActiveLanguage(option.code)}
-                className={`relative flex items-center justify-center rounded border px-1.5 py-1 transition ${
+                className={`relative flex items-center justify-center rounded border px-1 py-0.5 transition ${
                   isActive
                     ? 'border-slate-400 bg-slate-50 ring-2 ring-slate-200'
                     : 'border-slate-200 hover:border-slate-300'
@@ -85,8 +85,8 @@ export function LanguageToggleInput({
                 <img
                   src={option.flagSrc}
                   alt={`${option.label} flag`}
-                  width={24}
-                  height={16}
+                  width={20}
+                  height={14}
                   loading='lazy'
                 />
                 {hasValue ? (


### PR DESCRIPTION
Reduce the size of country flags next to labels and adjust button padding to ensure they fit within standard label height.

The previous larger flag sizes (24x16) and associated padding caused the label row height to be higher than other labels, corrupting the design. This change standardizes the flag size to 20x14 (matching existing table flags) and tightens button padding to maintain uniform label row height.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-e47733ea-1497-4e6e-b6ed-98bbf0efb583"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e47733ea-1497-4e6e-b6ed-98bbf0efb583"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

