### PR TITLE
fix: resolve dependency failures from PR 248 and 250

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,7 +29,6 @@ updates:
       prefix: "chore(deps)"
     labels:
       - "dependencies"
-      - "infrastructure"
     groups:
       aws-cdk:
         patterns:
@@ -61,7 +60,6 @@ updates:
       prefix: "chore(deps)"
     labels:
       - "dependencies"
-      - "backend"
     groups:
       aws:
         patterns:
@@ -86,6 +84,13 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # psycopg[binary] currently requires psycopg-binary releases that
+      # lag behind psycopg minor versions, so only accept patch updates.
+      - dependency-name: "psycopg"
+        update-types: ["version-update:semver-minor", "version-update:semver-major"]
+      - dependency-name: "psycopg-binary"
+        update-types: ["version-update:semver-minor", "version-update:semver-major"]
 
   # Pub - Flutter mobile app
   - package-ecosystem: "pub"
@@ -97,7 +102,6 @@ updates:
       prefix: "chore(deps)"
     labels:
       - "dependencies"
-      - "mobile"
     groups:
       flutter:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,7 @@ updates:
       prefix: "ci"
     labels:
       - "dependencies"
+      - "infrastructure"
     groups:
       github-actions:
         patterns:
@@ -29,6 +30,7 @@ updates:
       prefix: "chore(deps)"
     labels:
       - "dependencies"
+      - "infrastructure"
     groups:
       aws-cdk:
         patterns:
@@ -60,6 +62,7 @@ updates:
       prefix: "chore(deps)"
     labels:
       - "dependencies"
+      - "backend"
     groups:
       aws:
         patterns:
@@ -102,6 +105,7 @@ updates:
       prefix: "chore(deps)"
     labels:
       - "dependencies"
+      - "mobile"
     groups:
       flutter:
         patterns:

--- a/backend/infrastructure/package-lock.json
+++ b/backend/infrastructure/package-lock.json
@@ -597,9 +597,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,8 +1,8 @@
-alembic==1.18.3
+alembic==1.18.4
 boto3==1.42.78
 pyjwt[crypto]==2.12.1
 pydantic==2.12.5
 psycopg[binary]==3.2.13
-sqlalchemy==2.0.46
+sqlalchemy==2.0.48
 phonenumbers==9.0.26
 pycountry==26.2.16


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Updated backend infrastructure lockfile to include `brace-expansion@5.0.5` (aligns with PR #248).
- Updated backend Python dependencies to:
  - `alembic==1.18.4`
  - `sqlalchemy==2.0.48`
  - keep `psycopg[binary]==3.2.13` for compatibility with currently published `psycopg-binary` wheels.
- Updated `.github/dependabot.yml`:
  - restored repository labels (`infrastructure`, `backend`, `mobile`) as requested.
  - added ignore rules for `psycopg`/`psycopg-binary` minor+major bumps so dependabot does not open currently-uninstallable updates.

## Why
- PR #248 had a failed Python dependency audit on its snapshot.
- PR #250 failed Checkov job during CDK synth because `psycopg[binary]==3.3.3` requires `psycopg-binary==3.3.3`, which is not published for CI targets.

## Validation
- `python3 -m pre_commit run ruff-format --all-files`
- `python3 -m pip install -r backend/requirements.txt`
- `npx cdk synth --quiet --output cdk.out` (from `backend/infrastructure`)
- `pip-audit` check run via local CLI with pinned dependency mode (`--no-deps --disable-pip`): no known vulnerabilities found.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d438c01-b3b8-4157-95b0-07d80984cf10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d438c01-b3b8-4157-95b0-07d80984cf10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

