### PR TITLE
chore(ci): ignore bundled brace-expansion dependabot refresh

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,6 +48,11 @@ updates:
           - "minor"
           - "patch"
     ignore:
+      # aws-cdk-lib ships a bundled minimatch/brace-expansion tree inside
+      # its published tarball. Dependabot cannot update bundled files and
+      # fails refreshes with NoChangeError for brace-expansion.
+      # We patch the bundled copy via backend/infrastructure postinstall.
+      - dependency-name: "brace-expansion"
       # Ignore major version updates - review manually
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -211,6 +211,8 @@ Lambdas or NAT Gateway.
 - Weekly schedule (Mondays) to reduce PR noise.
 - Dependencies grouped by category (AWS CDK, Firebase, database, etc.).
 - Major version updates ignored to require manual review.
+- `brace-expansion` is ignored in `/backend/infrastructure` because
+  `aws-cdk-lib` bundles it; `postinstall` patches the bundled copy.
 - PRs labeled by ecosystem (`dependencies`, `ci`, `backend`, `mobile`, `infrastructure`).
 
 **Dependabot commands:**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Investigated failed GitHub Actions run `23729332963` (`Dependabot Updates`) and identified root cause from logs:
  - `Dependabot::NpmAndYarn::FileUpdater::NoChangeError`
  - dependency: `brace-expansion`
  - ecosystem directory: `/backend/infrastructure`
- Added a targeted Dependabot ignore rule for `brace-expansion` in `.github/dependabot.yml`.
- Documented the rationale in `docs/architecture/decisions.md`.

## Root Cause
`aws-cdk-lib` bundles `minimatch` and `brace-expansion` inside its published tarball (`inBundle` entries in lockfile). Dependabot attempts to refresh a security PR for `brace-expansion` by running a lockfile-only npm update, but no repository files can be changed for the bundled copy, causing `NoChangeError` and failing the run.

## Why this fix
- Prevents recurring Dependabot workflow failures for an unpatchable bundled transitive dependency.
- Maintains mitigation path already present in the repo (`backend/infrastructure/scripts/patch-bundled-minimatch.js` executed by postinstall).
- Keeps other dependency updates active.

## Files changed
- `.github/dependabot.yml`
- `docs/architecture/decisions.md`

## Validation
- Parsed `.github/dependabot.yml` successfully with Python YAML loader.

## Notes
- No API endpoints or database schema were changed.
- No seed-data assessment required (no DB changes).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d673db29-018d-4ae0-8db5-f5e396d15bac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d673db29-018d-4ae0-8db5-f5e396d15bac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

