### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# Agents
+
+## Cursor Cloud specific instructions
+
+### Services overview
+
+| Service | Directory | Runtime | Purpose |
+|---------|-----------|---------|---------|
+| Python backend | `backend/` | Python 3.12 | Lambda handlers, DB migrations, tests |
+| Admin web | `apps/admin_web/` | Node.js 24 (npm) | Next.js admin SPA |
+| CDK infrastructure | `backend/infrastructure/` | Node.js 24 (npm) | AWS CDK IaC |
+| Flutter app | `apps/siutindei_app/` | Flutter stable | Mobile app (not set up in cloud) |
+
+### Running services
+
+- **Admin web dev server**: `cd apps/admin_web && npm run dev` (port 3000)
+- **PostgreSQL**: `service postgresql start` then connect at `postgresql+psycopg://postgres:postgres@localhost:5432/backend_test`
+
+### Lint / Test / Build commands
+
+See `package.json` scripts and `.github/workflows/lint.yml` / `test.yml` for canonical commands. Key shortcuts:
+
+- **Python lint**: `ruff check backend/` and `ruff format --check backend/`
+- **Python tests**: `PYTHONPATH=backend/src DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5432/backend_test python3 -m pytest tests backend`
+- **Admin web lint**: `cd apps/admin_web && npm run lint`
+- **Admin web typecheck**: `cd apps/admin_web && npm run typecheck`
+- **Admin web E2E**: `cd apps/admin_web && npx playwright test` (requires Chromium; dev server must be running on port 3000)
+- **CDK build**: `cd backend/infrastructure && npm run build`
+- **Pre-commit (all)**: `pre-commit run --all-files`
+
+### Non-obvious caveats
+
+- The system Python has debian-managed packages (PyJWT, etc.) that conflict with pip. Use `pip install --ignore-installed` when installing backend deps to avoid "Cannot uninstall" errors.
+- Alembic migrations require `DATABASE_URL` env var. Run from workspace root: `python3 -m alembic -c backend/db/alembic.ini upgrade head`.
+- Node.js is installed via nvm at `/home/ubuntu/.nvm`. Source it before using node/npm: `export NVM_DIR="/home/ubuntu/.nvm" && . "$NVM_DIR/nvm.sh"`.
+- PostgreSQL pg_hba.conf must be set to `md5` auth (not `peer`) for password-based connections. After install, run: `sed -i 's/local\s*all\s*all\s*peer/local all all md5/' /etc/postgresql/16/main/pg_hba.conf && service postgresql restart`.
+- E2E tests for login/auth-related flows require Cognito env vars. Tests that don't need real auth sessions pass; authenticated flow tests fail without a real Cognito pool. The test fixtures mock auth via `test-fixtures.ts`.
+- The admin web `.env.local` needs `NEXT_PUBLIC_API_BASE_URL`, `NEXT_PUBLIC_COGNITO_DOMAIN`, `NEXT_PUBLIC_COGNITO_CLIENT_ID`, `NEXT_PUBLIC_COGNITO_USER_POOL_ID` for full functionality. The dev server starts without them (shows config warnings).
+- Python formatting rule: run `pre-commit run ruff-format --all-files` before any Python commit (per `.cursorrules`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud-specific development instructions for future agents working on this codebase.

## What's included

- Services overview table (Python backend, Admin web, CDK infrastructure, Flutter app)
- Commands to run each service locally
- Lint/test/build command reference
- Non-obvious caveats discovered during environment setup (pip conflicts, nvm path, PostgreSQL auth config, Cognito env vars for E2E)

## Environment verification

All services were verified working:
- Python 3.12 backend: 205 tests passing, ruff lint clean
- Admin web (Next.js): ESLint + TypeScript typecheck clean, dev server running, build succeeds
- CDK infrastructure: TypeScript build clean
- PostgreSQL 16: migrations applied successfully
- Playwright E2E infrastructure: functional (partial pass due to missing Cognito config)

[Admin web login page running on localhost:3000](https://cursor.com/agents/bc-7886fe8e-7b15-41f2-8440-1181bf27e48e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin_web_login_page.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7886fe8e-7b15-41f2-8440-1181bf27e48e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7886fe8e-7b15-41f2-8440-1181bf27e48e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

