### PR TITLE
fix(ci): route PublicWww* params to public-www stack in deploy-backend

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -485,9 +485,19 @@ jobs:
           admin_web_stack = "lxsoftware-siutindei-admin-web"
           api_stack = "lxsoftware-siutindei"
           waf_stack = "lxsoftware-siutindei-waf"
+          public_www_stack = "lxsoftware-siutindei-public-www"
           admin_web_params = {"AdminWebDomainName", "AdminWebCertificateArn", "WafWebAclArn"}
           # WAF stack has no parameters that need to be passed
           waf_params = set()
+          # Public website stack params. Note: WafWebAclArn is shared with
+          # admin-web; it stays in admin_web_params because deploy-backend.yml
+          # does not deploy the public-www stack (deploy-public-www.yml does).
+          public_www_params = {
+              "PublicWwwDomainName",
+              "PublicWwwCertificateArn",
+              "PublicWwwStagingDomainName",
+              "PublicWwwStagingCertificateArn",
+          }
           params = {}
           for path in paths:
               with open(path, "r", encoding="utf-8") as handle:
@@ -509,6 +519,8 @@ jobs:
                   target_stack = waf_stack
               elif key in admin_web_params:
                   target_stack = admin_web_stack
+              elif key in public_www_params:
+                  target_stack = public_www_stack
               else:
                   target_stack = api_stack
               if target_stack not in stack_set:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the `Deploy Backend` workflow which has been failing on every push to `main` since commit `b27f5fa` ("Scaffold apps/public_www and supporting CDK/CI/docs"). Latest failure: [run 25672232707](https://github.com/lcacchiani/siutindei/actions/runs/25672232707).

## Root cause

The Python helper inside `.github/workflows/deploy-backend.yml` that translates `backend/infrastructure/params/production.json` into `--parameters StackName:Key=Value` arguments only knew about three target stacks: `api_stack`, `admin_web_stack`, `waf_stack`. Anything not matched fell through to `api_stack`.

Commit `b27f5fa` added a fourth stack (`lxsoftware-siutindei-public-www`) and four new keys to `production.json`:

- `PublicWwwDomainName`
- `PublicWwwCertificateArn`
- `PublicWwwStagingDomainName`
- `PublicWwwStagingCertificateArn`

The router was not updated, so all four were emitted as `--parameters lxsoftware-siutindei:PublicWww*=...`. The API stack template has no such `CfnParameter`s, and CloudFormation rejected every changeset with:

```
Parameters: [PublicWwwDomainName, PublicWwwStagingDomainName,
PublicWwwStagingCertificateArn, PublicWwwCertificateArn] do not exist
in the template
##[error]Process completed with exit code 1.
```

## Fix

Add `public_www_stack` and a `public_www_params` set, plus an `elif` branch in the routing chain so those four keys are addressed to `lxsoftware-siutindei-public-www`.

`deploy-backend.yml` does not deploy the public-www stack (that's done by `deploy-public-www.yml` via `scripts/deploy/deploy-public-www.sh`). The default deploy stack list is `["lxsoftware-siutindei", "lxsoftware-siutindei-admin-web"]`, so the existing `if target_stack not in stack_set: continue` guard now silently drops the four `PublicWww*` keys for the default deploy — exactly the desired behaviour. The keys would be addressed correctly if a future caller ever set `CDK_STACKS=lxsoftware-siutindei-public-www`.

`WafWebAclArn` intentionally remains in `admin_web_params` (and is not duplicated in `public_www_params`) because this workflow does not touch public-www.

## Verification

I extracted the helper script and ran it locally against the real `backend/infrastructure/params/production.json` for three scenarios:

✅ **Default stack list (api + admin-web)** — no `PublicWww*` params emitted to anything (previously they were emitted to `lxsoftware-siutindei`, breaking the deploy):

```
=== PublicWww keys filtered out? ===
(none — correct)
```

✅ **`CDK_STACKS=lxsoftware-siutindei-public-www`** — all four routed to the right stack:

```
lxsoftware-siutindei-public-www:PublicWwwCertificateArn=arn:aws:acm:us-east-1:...
lxsoftware-siutindei-public-www:PublicWwwDomainName=www.siutindei.lx-software.com
lxsoftware-siutindei-public-www:PublicWwwStagingCertificateArn=arn:aws:acm:us-east-1:...
lxsoftware-siutindei-public-www:PublicWwwStagingDomainName=www-staging.siutindei.lx-software.com
```

✅ **`CDK_STACKS=lxsoftware-siutindei-admin-web`** — `AdminWeb*` + `WafWebAclArn` still routed to admin-web (regression check):

```
lxsoftware-siutindei-admin-web:AdminWebCertificateArn=...
lxsoftware-siutindei-admin-web:AdminWebDomainName=siutindei.lx-software.com
lxsoftware-siutindei-admin-web:WafWebAclArn=...
```

✅ **YAML syntax check** — `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-backend.yml'))"` parses cleanly.

End-to-end CI verification will happen automatically when this PR triggers `Deploy Backend`.

## Risk

Pure CI-script change. No infrastructure / CDK / app code is modified. The change is additive (new stack constant + new param set + new `elif`) and cannot affect the routing of any existing key.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb327fdd-a097-4514-8298-6e65242d81cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb327fdd-a097-4514-8298-6e65242d81cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

