### PR TITLE
fix(admin_web): spurious “Enter your work email” on social login

### DIFF
--- a/apps/admin_web/src/components/login-screen.tsx
+++ b/apps/admin_web/src/components/login-screen.tsx
@@ -249,7 +249,6 @@ export function LoginScreen() {
                       autoFocus
                       className={showEmailError ? errorInputClassName : ''}
                       aria-invalid={showEmailError || undefined}
-                      onBlur={() => setEmailTouched(true)}
                     />
                     {showEmailError ? (
                       <p className='text-xs text-red-600'>{emailError}</p>
@@ -290,7 +289,6 @@ export function LoginScreen() {
                       autoFocus
                       className={showCodeError ? errorInputClassName : ''}
                       aria-invalid={showCodeError || undefined}
-                      onBlur={() => setCodeTouched(true)}
                     />
                     {showCodeError ? (
                       <p className='text-xs text-red-600'>{codeError}</p>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The login email field uses `autoFocus`. Clicking a social sign-in button moved focus away from that input, which triggered `onBlur` and marked the field as “touched” while it was still empty. That made the empty-email validation message appear even though the user chose OAuth, including while the hosted login / redirect flow was in progress.

## Changes

- Removed `onBlur` → `setEmailTouched(true)` from the work email input.
- Removed the same pattern from the verification code input for consistency (e.g. clicking “Use a different email” could trigger the same spurious code error).

Validation still runs on submit and as soon as the user types (`onChange` sets touched).

## Testing

- `npm run lint` and `npm run typecheck` in `apps/admin_web`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-198cb683-7977-4ea4-a0b5-2448a68c085d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-198cb683-7977-4ea4-a0b5-2448a68c085d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

