### PR TITLE
Mark sitemap and robots routes force-static for export build

### DIFF
--- a/apps/public_www/src/app/robots.ts
+++ b/apps/public_www/src/app/robots.ts
@@ -1,6 +1,8 @@
 import type { MetadataRoute } from 'next';
 import { getSiteConfig } from '@/lib/site-config';
 
+export const dynamic = 'force-static';
+
 // Production robots.txt. The deploy script overwrites this with a deny-all
 // version when syncing to the staging bucket so that staging never gets
 // indexed regardless of what is checked in here. CloudFront also adds an

--- a/apps/public_www/src/app/sitemap.ts
+++ b/apps/public_www/src/app/sitemap.ts
@@ -1,6 +1,8 @@
 import type { MetadataRoute } from 'next';
 import { getSiteConfig } from '@/lib/site-config';
 
+export const dynamic = 'force-static';
+
 export default function sitemap(): MetadataRoute.Sitemap {
   const { siteOrigin } = getSiteConfig();
   const now = new Date();


### PR DESCRIPTION
Next.js 16 with output: export requires dynamic = force-static on metadata routes so they are generated at build time.