### PR TITLE
docs(flutter): align README with scrollCacheExtent deprecation fix

### DIFF
--- a/apps/siutindei_app/README.md
+++ b/apps/siutindei_app/README.md
@@ -262,7 +262,7 @@ The app follows [Flutter performance best practices](https://docs.flutter.dev/pe
 - Widget extraction for isolation
 - `RepaintBoundary` for expensive widgets
 - Cached layout objects (BorderRadius, etc.)
-- `ListView.builder` with `cacheExtent`
+- `ListView.builder` with `scrollCacheExtent` (Flutter 3.41+)
 - Image caching with `cacheWidth`/`cacheHeight`
 
 ## Contributing


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The **Lint Dart** failure (`deprecated_member_use` for `cacheExtent` on `search_screen.dart:416`) is already fixed on `main` via #295:

- Import `ScrollCacheExtent` from `package:flutter/rendering.dart`
- Replace `cacheExtent: 200` with `scrollCacheExtent: const ScrollCacheExtent.pixels(200)`

Verified locally with Flutter **3.44.0** stable (`flutter pub get && flutter analyze` → no issues).

This PR only updates the performance section in `apps/siutindei_app/README.md` to document `scrollCacheExtent` instead of the removed `cacheExtent` API.

## If CI still fails on another branch

Rebase or merge `main` so your branch picks up the #295 change.

## Testing

- [x] `flutter analyze` in `apps/siutindei_app` (Flutter 3.44.0)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d52a331c-60bf-4fe3-8b82-8f9c6bde2bc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d52a331c-60bf-4fe3-8b82-8f9c6bde2bc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

