### PR TITLE
Public website: evolvesprouts-style i18n, 12-column page grid, GTM/Pixel SEO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ lib64/
 !apps/admin_web/src/lib/**
 !apps/public_www/src/lib/
 !apps/public_www/src/lib/**
+!apps/public_www/tests/lib/
+!apps/public_www/tests/lib/**
 parts/
 sdist/
 var/
@@ -196,6 +198,8 @@ cython_debug/
 node_modules/
 apps/admin_web/.next/
 apps/admin_web/out/
+apps/public_www/.next/
+apps/public_www/out/
 
 # Playwright
 apps/admin_web/playwright-report/

--- a/apps/public_www/.env.example
+++ b/apps/public_www/.env.example
@@ -21,3 +21,10 @@ NEXT_PUBLIC_INSTAGRAM_URL=
 # a deny-all robots.txt and the CloudFront response headers policy adds an
 # X-Robots-Tag noindex header. The badge below is purely cosmetic.
 NEXT_PUBLIC_STAGING_BADGE_ENABLED=false
+
+# Analytics (optional). Scripts load only on allow-listed hosts (defaults to
+# the site hostname derived from NEXT_PUBLIC_SITE_ORIGIN).
+NEXT_PUBLIC_GTM_ID=
+NEXT_PUBLIC_GTM_ALLOWED_HOSTS=
+NEXT_PUBLIC_META_PIXEL_ID=
+NEXT_PUBLIC_META_PIXEL_ALLOWED_HOSTS=

--- a/apps/public_www/README.md
+++ b/apps/public_www/README.md
@@ -76,9 +76,19 @@ Optional `NEXT_PUBLIC_*` variables documented in `.env.example` are read by
 - TypeScript only.
 - No inline `<svg>` markup in components — use SVGs from `public/images/`.
 - No `dangerouslySetInnerHTML`, no `eval`/`new Function`.
-- All user-visible copy lives in components for now (single locale). When a
-  second locale is added, follow the evolvesprouts pattern of
-  `src/content/<locale>.json` + `src/app/[locale]/...`.
+- **i18n:** `src/content/<locale>.json` (e.g. `en.json`, `zh-HK.json`) is the
+  source of truth for copy, navigation, SEO strings, and per-page body grids.
+  Routes live under `src/app/[locale]/...` with root redirects (e.g. `/` →
+  `/en/`).
+- **Page template:** `PageLayout` = shared header (`Navbar`) + `main` +
+  shared footer (`Footer`). Page-specific content is rendered by `PageBodyGrid`.
+- **12-column body grid:** Each page defines `pages.<key>.body.rows[]` with
+  cells (`component`, `colStart`, `colSpan`, optional `props`). Register new
+  body components in `page-body-grid.tsx`.
+- **SEO / analytics:** `buildLocalizedMetadata` (canonical + hreflang),
+  optional `NEXT_PUBLIC_GTM_ID` and `NEXT_PUBLIC_META_PIXEL_ID` with host
+  allow-lists (same pattern as
+  [evolvesprouts](https://github.com/lcacchiani/evolvesprouts)).
 
 See the `Public Website` section in the repository root `.cursorrules` for the
 authoritative checklist.

--- a/apps/public_www/public/scripts/init-gtm.js
+++ b/apps/public_www/public/scripts/init-gtm.js
@@ -1,0 +1,42 @@
+(function initGtm() {
+  function parseAllowedHosts(rawValue) {
+    if (typeof rawValue !== 'string') {
+      return [];
+    }
+
+    var seen = {};
+    return rawValue
+      .split(',')
+      .map(function normalizeHost(hostValue) {
+        return hostValue.trim().toLowerCase();
+      })
+      .filter(function isUniqueHost(hostValue) {
+        if (hostValue === '' || seen[hostValue]) {
+          return false;
+        }
+        seen[hostValue] = true;
+        return true;
+      });
+  }
+
+  var allowedHosts = parseAllowedHosts(
+    document.documentElement.getAttribute('data-gtm-allowed-hosts'),
+  );
+  var currentHost = window.location.hostname.toLowerCase();
+  if (allowedHosts.length === 0 || allowedHosts.indexOf(currentHost) === -1) {
+    return;
+  }
+
+  var gtmId = document.documentElement.getAttribute('data-gtm-id');
+  if (!gtmId || gtmId.indexOf('GTM-') !== 0) {
+    return;
+  }
+
+  window.dataLayer = window.dataLayer || [];
+  window.dataLayer.push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+
+  var script = document.createElement('script');
+  script.async = true;
+  script.src = 'https://www.googletagmanager.com/gtm.js?id=' + gtmId;
+  document.head.appendChild(script);
+})();

--- a/apps/public_www/public/scripts/init-meta-pixel.js
+++ b/apps/public_www/public/scripts/init-meta-pixel.js
@@ -1,0 +1,65 @@
+(function initMetaPixel() {
+  function parseAllowedHosts(rawValue) {
+    if (typeof rawValue !== 'string') {
+      return [];
+    }
+
+    var seen = {};
+    return rawValue
+      .split(',')
+      .map(function normalizeHost(hostValue) {
+        return hostValue.trim().toLowerCase();
+      })
+      .filter(function isUniqueHost(hostValue) {
+        if (hostValue === '' || seen[hostValue]) {
+          return false;
+        }
+        seen[hostValue] = true;
+        return true;
+      });
+  }
+
+  var allowedHosts = parseAllowedHosts(
+    document.documentElement.getAttribute('data-meta-pixel-allowed-hosts'),
+  );
+  var currentHost = window.location.hostname.toLowerCase();
+  if (allowedHosts.length === 0 || allowedHosts.indexOf(currentHost) === -1) {
+    return;
+  }
+
+  var pixelId = document.documentElement.getAttribute('data-meta-pixel-id');
+  if (!pixelId || !/^\d+$/.test(pixelId)) {
+    return;
+  }
+
+  var f = window;
+  var b = document;
+  var e = 'script';
+  var n = function () {
+    n.callMethod
+      ? n.callMethod.apply(n, arguments)
+      : n.queue.push(arguments);
+  };
+  if (f.fbq) {
+    return;
+  }
+  f.fbq = n;
+  n.push = n;
+  n.loaded = true;
+  n.version = '2.0';
+  n.queue = [];
+  f._fbq = n;
+
+  var t = b.createElement(e);
+  t.async = true;
+  t.src = 'https://connect.facebook.net/en_US/fbevents.js';
+  var s = b.getElementsByTagName(e)[0];
+  if (s && s.parentNode) {
+    s.parentNode.insertBefore(t, s);
+  } else {
+    b.head.appendChild(t);
+  }
+
+  n('init', pixelId);
+  n('track', 'PageView');
+})();

--- a/apps/public_www/public/scripts/set-html-lang.js
+++ b/apps/public_www/public/scripts/set-html-lang.js
@@ -1,0 +1,6 @@
+(function setHtmlLang() {
+  var match = location.pathname.match(/^\/(en|zh-HK)(?:\/|$)/);
+  if (match) {
+    document.documentElement.lang = match[1];
+  }
+})();

--- a/apps/public_www/scripts/inject-csp-meta.mjs
+++ b/apps/public_www/scripts/inject-csp-meta.mjs
@@ -1,27 +1,57 @@
 // Inserts a <meta http-equiv="Content-Security-Policy"> tag into every
-// generated HTML in the static export. This complements the
-// Content-Security-Policy response header set by the CloudFront response
-// headers policy: the meta tag also applies when the document is opened from
-// disk during local QA and gives an extra layer of defense in depth.
+// generated HTML in the static export. Aligns with evolvesprouts: extend
+// script-src / connect-src when GTM or Meta Pixel init scripts are enabled.
 
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
 const OUT_DIR = path.resolve('out');
 const META_MARKER = '<!-- csp-meta -->';
-const CSP_DIRECTIVES = [
-  "default-src 'self'",
-  "img-src 'self' data:",
-  "style-src 'self' 'unsafe-inline'",
-  "script-src 'self'",
-  "font-src 'self' data:",
-  "connect-src 'self'",
-  "base-uri 'self'",
-  "object-src 'none'",
-  "frame-ancestors 'none'",
-].join('; ');
 
-const META_TAG = `<meta http-equiv="Content-Security-Policy" content="${CSP_DIRECTIVES}">`;
+const GTM_SCRIPT_ORIGINS = [
+  'https://www.googletagmanager.com',
+  'https://googleads.g.doubleclick.net',
+  'https://www.googleadservices.com',
+];
+const GTM_CONNECT_ORIGINS = [
+  'https://www.google-analytics.com',
+  'https://analytics.google.com',
+  'https://region1.google-analytics.com',
+  'https://stats.g.doubleclick.net',
+  'https://www.google.com',
+  'https://googleads.g.doubleclick.net',
+];
+const META_PIXEL_SCRIPT_ORIGINS = ['https://connect.facebook.net'];
+const META_PIXEL_CONNECT_ORIGINS = ['https://www.facebook.com'];
+
+function buildCspDirectives() {
+  const hasGtm = Boolean(process.env.NEXT_PUBLIC_GTM_ID?.trim());
+  const hasMetaPixel = Boolean(process.env.NEXT_PUBLIC_META_PIXEL_ID?.trim());
+
+  const scriptSources = ["'self'"];
+  const connectSources = ["'self'"];
+
+  if (hasGtm) {
+    scriptSources.push(...GTM_SCRIPT_ORIGINS);
+    connectSources.push(...GTM_CONNECT_ORIGINS);
+  }
+  if (hasMetaPixel) {
+    scriptSources.push(...META_PIXEL_SCRIPT_ORIGINS);
+    connectSources.push(...META_PIXEL_CONNECT_ORIGINS);
+  }
+
+  return [
+    "default-src 'self'",
+    `img-src 'self' data: https:`,
+    "style-src 'self' 'unsafe-inline'",
+    `script-src ${[...new Set(scriptSources)].join(' ')}`,
+    "font-src 'self' data:",
+    `connect-src ${[...new Set(connectSources)].join(' ')}`,
+    "base-uri 'self'",
+    "object-src 'none'",
+    "frame-ancestors 'none'",
+  ].join('; ');
+}
 
 async function* walk(dir) {
   const entries = await fs.readdir(dir, { withFileTypes: true });
@@ -35,7 +65,7 @@ async function* walk(dir) {
   }
 }
 
-async function injectIntoFile(filePath) {
+async function injectIntoFile(filePath, metaTag) {
   const original = await fs.readFile(filePath, 'utf8');
   if (original.includes(META_MARKER)) {
     return false;
@@ -44,7 +74,7 @@ async function injectIntoFile(filePath) {
   if (!headOpenRegex.test(original)) {
     return false;
   }
-  const replacement = `<head$1>\n    ${META_MARKER}\n    ${META_TAG}`;
+  const replacement = `<head$1>\n    ${META_MARKER}\n    ${metaTag}`;
   const updated = original.replace(headOpenRegex, replacement);
   await fs.writeFile(filePath, updated, 'utf8');
   return true;
@@ -58,11 +88,12 @@ async function main() {
     process.exit(1);
   }
 
+  const metaTag = `<meta http-equiv="Content-Security-Policy" content="${buildCspDirectives()}">`;
   let updatedCount = 0;
   let totalCount = 0;
   for await (const filePath of walk(OUT_DIR)) {
     totalCount += 1;
-    const updated = await injectIntoFile(filePath);
+    const updated = await injectIntoFile(filePath, metaTag);
     if (updated) {
       updatedCount += 1;
     }

--- a/apps/public_www/src/app/[locale]/about/page.tsx
+++ b/apps/public_www/src/app/[locale]/about/page.tsx
@@ -1,0 +1,43 @@
+import { MarketingPage } from '@/components/pages/marketing-page';
+import {
+  generateLocaleStaticParams,
+  type LocaleRouteProps,
+  resolveLocalePageContext,
+} from '@/lib/locale-page';
+import { ROUTES } from '@/lib/routes';
+import { buildLocalizedMetadata } from '@/lib/seo';
+import { getSiteConfig } from '@/lib/site-config';
+
+export function generateStaticParams() {
+  return generateLocaleStaticParams();
+}
+
+export async function generateMetadata({ params }: LocaleRouteProps) {
+  const { locale, content } = await resolveLocalePageContext(params);
+  const { siteName } = getSiteConfig();
+
+  return buildLocalizedMetadata({
+    locale,
+    path: ROUTES.about,
+    title: content.seo.about.title,
+    description: content.seo.about.description,
+    siteName,
+    socialImage: {
+      url: content.seo.defaultSocialImage,
+      alt: content.seo.defaultSocialImageAlt,
+    },
+  });
+}
+
+export default async function AboutRoutePage({ params }: LocaleRouteProps) {
+  const { locale, content } = await resolveLocalePageContext(params);
+
+  return (
+    <MarketingPage
+      locale={locale}
+      content={content}
+      body={content.pages.about.body}
+      currentPath={ROUTES.about}
+    />
+  );
+}

--- a/apps/public_www/src/app/[locale]/layout.tsx
+++ b/apps/public_www/src/app/[locale]/layout.tsx
@@ -1,0 +1,67 @@
+import type { ReactNode } from 'react';
+
+import {
+  generateLocaleStaticParams,
+  type LocaleRouteParams,
+  resolveLocalePageContext,
+} from '@/lib/locale-page';
+import { localizePath } from '@/lib/locale-routing';
+import { ROUTES } from '@/lib/routes';
+import { resolvePublicSiteConfig } from '@/lib/site-config';
+
+interface LocaleLayoutProps {
+  readonly children: ReactNode;
+  readonly params: LocaleRouteParams;
+}
+
+export function generateStaticParams() {
+  return generateLocaleStaticParams();
+}
+
+export default async function LocaleLayout({
+  children,
+  params,
+}: LocaleLayoutProps) {
+  const { locale, content } = await resolveLocalePageContext(params);
+  const direction = content.meta.direction === 'rtl' ? 'rtl' : 'ltr';
+  const publicSiteConfig = resolvePublicSiteConfig();
+  const noscriptCopy = content.common.shell.noscript;
+  const localizedHomeHref = localizePath(ROUTES.home, locale);
+  const localizedContactHref = `${localizePath(ROUTES.home, locale)}#contact`;
+
+  return (
+    <div data-locale={locale} dir={direction}>
+      <noscript>
+        <section className="mx-auto mt-4 max-w-3xl rounded-xl border border-black/10 bg-white px-4 py-4 text-sm text-black/80">
+          <p className="font-semibold text-black">{noscriptCopy.title}</p>
+          <p className="mt-2">{noscriptCopy.description}</p>
+          <p className="mt-3 flex flex-wrap gap-4">
+            <a
+              href={localizedHomeHref}
+              className="font-semibold underline underline-offset-4"
+            >
+              {noscriptCopy.homeLabel}
+            </a>
+            <a
+              href={localizedContactHref}
+              className="font-semibold underline underline-offset-4"
+            >
+              {noscriptCopy.contactLabel}
+            </a>
+          </p>
+        </section>
+      </noscript>
+      {children}
+      {publicSiteConfig.whatsappUrl ? (
+        <a
+          href={publicSiteConfig.whatsappUrl}
+          className="fixed bottom-6 right-6 z-40 rounded-full bg-brand-500 px-4 py-3 text-sm font-semibold text-white shadow-lg transition hover:bg-brand-600"
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          WhatsApp
+        </a>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/public_www/src/app/[locale]/page.tsx
+++ b/apps/public_www/src/app/[locale]/page.tsx
@@ -1,0 +1,43 @@
+import { MarketingPage } from '@/components/pages/marketing-page';
+import {
+  generateLocaleStaticParams,
+  type LocaleRouteProps,
+  resolveLocalePageContext,
+} from '@/lib/locale-page';
+import { ROUTES } from '@/lib/routes';
+import { buildLocalizedMetadata } from '@/lib/seo';
+import { getSiteConfig } from '@/lib/site-config';
+
+export function generateStaticParams() {
+  return generateLocaleStaticParams();
+}
+
+export async function generateMetadata({ params }: LocaleRouteProps) {
+  const { locale, content } = await resolveLocalePageContext(params);
+  const { siteName } = getSiteConfig();
+
+  return buildLocalizedMetadata({
+    locale,
+    path: ROUTES.home,
+    title: content.seo.home.title,
+    description: content.seo.home.description,
+    siteName,
+    socialImage: {
+      url: content.seo.defaultSocialImage,
+      alt: content.seo.defaultSocialImageAlt,
+    },
+  });
+}
+
+export default async function HomeRoutePage({ params }: LocaleRouteProps) {
+  const { locale, content } = await resolveLocalePageContext(params);
+
+  return (
+    <MarketingPage
+      locale={locale}
+      content={content}
+      body={content.pages.home.body}
+      currentPath={ROUTES.home}
+    />
+  );
+}

--- a/apps/public_www/src/app/about/page.tsx
+++ b/apps/public_www/src/app/about/page.tsx
@@ -4,6 +4,6 @@ import { DEFAULT_LOCALE } from '@/content';
 import { localizePath } from '@/lib/locale-routing';
 import { ROUTES } from '@/lib/routes';
 
-export default function RootPage() {
-  redirect(localizePath(ROUTES.home, DEFAULT_LOCALE));
+export default function AboutRedirectPage() {
+  redirect(localizePath(ROUTES.about, DEFAULT_LOCALE));
 }

--- a/apps/public_www/src/app/layout.tsx
+++ b/apps/public_www/src/app/layout.tsx
@@ -1,29 +1,58 @@
 import type { Metadata, Viewport } from 'next';
 import Script from 'next/script';
+import type { ReactNode } from 'react';
+
+import { GoogleTagManager } from '@/components/shared/google-tag-manager';
+import { MetaPixel } from '@/components/shared/meta-pixel';
+import enContent from '@/content/en.json';
 import { getSiteConfig } from '@/lib/site-config';
+import { getSiteHost, getSiteOrigin } from '@/lib/seo';
 import './globals.css';
+
+const GTM_ID = process.env.NEXT_PUBLIC_GTM_ID || '';
+const META_PIXEL_ID = process.env.NEXT_PUBLIC_META_PIXEL_ID || '';
+const rootShellContent = enContent.common.shell;
+
+function resolveGtmAllowedHosts(): string {
+  const configuredHosts = process.env.NEXT_PUBLIC_GTM_ALLOWED_HOSTS;
+  if (!configuredHosts || configuredHosts.trim() === '') {
+    return getSiteHost();
+  }
+
+  return configuredHosts;
+}
+
+function resolveMetaPixelAllowedHosts(): string {
+  const configuredHosts = process.env.NEXT_PUBLIC_META_PIXEL_ALLOWED_HOSTS;
+  if (!configuredHosts || configuredHosts.trim() === '') {
+    return getSiteHost();
+  }
+
+  return configuredHosts;
+}
 
 const siteConfig = getSiteConfig();
 
 export const metadata: Metadata = {
-  metadataBase: new URL(siteConfig.siteOrigin),
-  title: {
-    default: siteConfig.siteName,
-    template: `%s · ${siteConfig.siteName}`,
-  },
-  description: siteConfig.siteTagline,
+  metadataBase: new URL(getSiteOrigin()),
+  title: enContent.seo.fallbackTitle,
+  description: enContent.seo.fallbackDescription,
   applicationName: siteConfig.siteName,
+  icons: {
+    icon: '/favicon.ico',
+    shortcut: '/favicon.ico',
+  },
   openGraph: {
     type: 'website',
     siteName: siteConfig.siteName,
-    title: siteConfig.siteName,
-    description: siteConfig.siteTagline,
-    url: siteConfig.siteOrigin,
+    title: enContent.seo.fallbackTitle,
+    description: enContent.seo.fallbackDescription,
+    url: getSiteOrigin(),
   },
   twitter: {
     card: 'summary_large_image',
-    title: siteConfig.siteName,
-    description: siteConfig.siteTagline,
+    title: enContent.seo.fallbackTitle,
+    description: enContent.seo.fallbackDescription,
   },
 };
 
@@ -34,20 +63,53 @@ export const viewport: Viewport = {
 };
 
 interface RootLayoutProps {
-  readonly children: React.ReactNode;
+  readonly children: ReactNode;
 }
 
 export default function RootLayout({ children }: RootLayoutProps) {
+  const gtmAllowedHosts = resolveGtmAllowedHosts();
+  const metaPixelAllowedHosts = resolveMetaPixelAllowedHosts();
+
   return (
-    <html lang="en">
-      <body className="min-h-screen antialiased">
-        {children}
+    <html
+      lang="en"
+      suppressHydrationWarning
+      {...(GTM_ID
+        ? {
+            'data-gtm-id': GTM_ID,
+            'data-gtm-allowed-hosts': gtmAllowedHosts,
+          }
+        : {})}
+      {...(META_PIXEL_ID
+        ? {
+            'data-meta-pixel-id': META_PIXEL_ID,
+            'data-meta-pixel-allowed-hosts': metaPixelAllowedHosts,
+          }
+        : {})}
+    >
+      <body className="min-h-screen antialiased" suppressHydrationWarning>
+        <Script src="/scripts/set-html-lang.js" strategy="beforeInteractive" />
+        <a
+          href="#main-content"
+          className="sr-only fixed left-4 top-4 z-[80] rounded-md bg-black px-4 py-2 text-sm font-semibold text-white focus:not-sr-only focus:outline focus:outline-2 focus:outline-offset-2 focus:outline-black"
+        >
+          {rootShellContent.skipToMainContentLabel}
+        </a>
+        <div
+          id="environment-badge"
+          className="pointer-events-none fixed right-4 top-4 z-50 hidden rounded-md bg-amber-500 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-white shadow-md"
+        >
+          {rootShellContent.environmentBadgeLabel}
+        </div>
         {siteConfig.stagingBadgeEnabled ? (
           <Script
             src="/scripts/show-staging-badge.js"
             strategy="afterInteractive"
           />
         ) : null}
+        <GoogleTagManager />
+        <MetaPixel />
+        {children}
       </body>
     </html>
   );

--- a/apps/public_www/src/app/robots.ts
+++ b/apps/public_www/src/app/robots.ts
@@ -1,14 +1,13 @@
 import type { MetadataRoute } from 'next';
-import { getSiteConfig } from '@/lib/site-config';
+
+import { getSiteHost, getSiteOrigin } from '@/lib/seo';
 
 export const dynamic = 'force-static';
 
-// Production robots.txt. The deploy script overwrites this with a deny-all
-// version when syncing to the staging bucket so that staging never gets
-// indexed regardless of what is checked in here. CloudFront also adds an
-// X-Robots-Tag: noindex response header on the staging distribution.
 export default function robots(): MetadataRoute.Robots {
-  const { siteOrigin } = getSiteConfig();
+  const siteOrigin = getSiteOrigin();
+  const siteHost = getSiteHost();
+
   return {
     rules: [
       {
@@ -17,5 +16,6 @@ export default function robots(): MetadataRoute.Robots {
       },
     ],
     sitemap: `${siteOrigin}/sitemap.xml`,
+    host: siteHost,
   };
 }

--- a/apps/public_www/src/app/sitemap.ts
+++ b/apps/public_www/src/app/sitemap.ts
@@ -1,17 +1,22 @@
 import type { MetadataRoute } from 'next';
-import { getSiteConfig } from '@/lib/site-config';
+
+import { SUPPORTED_LOCALES } from '@/content';
+import { localizePath } from '@/lib/locale-routing';
+import { INDEXED_ROUTE_PATHS } from '@/lib/routes';
+import { getSiteOrigin } from '@/lib/seo';
 
 export const dynamic = 'force-static';
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const { siteOrigin } = getSiteConfig();
+  const siteOrigin = getSiteOrigin();
   const now = new Date();
-  return [
-    {
-      url: `${siteOrigin}/`,
+
+  return SUPPORTED_LOCALES.flatMap((locale) =>
+    INDEXED_ROUTE_PATHS.map((path) => ({
+      url: `${siteOrigin}${localizePath(path, locale)}`,
       lastModified: now,
-      changeFrequency: 'weekly',
-      priority: 1,
-    },
-  ];
+      changeFrequency: path === '/' ? 'weekly' : 'monthly',
+      priority: path === '/' ? 1 : 0.8,
+    })),
+  );
 }

--- a/apps/public_www/src/components/pages/marketing-page.tsx
+++ b/apps/public_www/src/components/pages/marketing-page.tsx
@@ -1,0 +1,28 @@
+import type { Locale, PageBodyGridConfig, SiteContent } from '@/content';
+import { PageBodyGrid } from '@/components/sections/grid/page-body-grid';
+import { PageLayout } from '@/components/shared/page-layout';
+
+interface MarketingPageProps {
+  readonly locale: Locale;
+  readonly content: SiteContent;
+  readonly body: PageBodyGridConfig;
+  readonly currentPath: string;
+}
+
+export function MarketingPage({
+  locale,
+  content,
+  body,
+  currentPath,
+}: MarketingPageProps) {
+  return (
+    <PageLayout
+      locale={locale}
+      navbarContent={content.navbar}
+      footerContent={content.footer}
+      currentPath={currentPath}
+    >
+      <PageBodyGrid locale={locale} content={content} body={body} />
+    </PageLayout>
+  );
+}

--- a/apps/public_www/src/components/sections/footer.tsx
+++ b/apps/public_www/src/components/sections/footer.tsx
@@ -1,8 +1,17 @@
+import type { FooterContent } from '@/content';
+import { formatContentTemplate } from '@/content/content-field-utils';
 import { getSiteConfig } from '@/lib/site-config';
 
-export function Footer() {
+interface FooterProps {
+  readonly content: FooterContent;
+}
+
+export function Footer({ content }: FooterProps) {
   const { siteName, contact } = getSiteConfig();
   const year = new Date().getFullYear();
+  const copyright = formatContentTemplate(content.copyrightTemplate, {
+    year: String(year),
+  });
 
   return (
     <footer
@@ -14,13 +23,12 @@ export function Footer() {
         <div className="grid gap-8 sm:grid-cols-2">
           <div>
             <p className="text-lg font-semibold text-white">{siteName}</p>
-            <p className="mt-2 text-sm text-brand-100">
-              An LX Software product. Hong Kong, SAR.
-            </p>
+            <p className="mt-2 text-sm text-brand-100">{content.tagline}</p>
           </div>
           <div className="text-sm sm:text-right">
+            <p className="font-semibold text-white">{content.contactHeading}</p>
             {contact.email ? (
-              <p>
+              <p className="mt-2">
                 <a
                   href={`mailto:${contact.email}`}
                   className="underline-offset-2 hover:underline"
@@ -56,7 +64,7 @@ export function Footer() {
           </div>
         </div>
         <p className="mt-8 border-t border-brand-600 pt-6 text-xs text-brand-100">
-          &copy; {year} LX Software Limited. All rights reserved.
+          {copyright}
         </p>
       </div>
     </footer>

--- a/apps/public_www/src/components/sections/grid/features-section.tsx
+++ b/apps/public_www/src/components/sections/grid/features-section.tsx
@@ -1,27 +1,10 @@
-interface Feature {
-  readonly title: string;
-  readonly description: string;
+import type { FeaturesContent } from '@/content';
+
+interface FeaturesSectionProps {
+  readonly content: FeaturesContent;
 }
 
-const FEATURES: readonly Feature[] = [
-  {
-    title: 'Vetted programs',
-    description:
-      'Every activity on Siu Tin Dei is reviewed by our team for safety, value, and pedagogical quality.',
-  },
-  {
-    title: 'Hong Kong focused',
-    description:
-      "Built for HK families: districts, languages, schedules, and pricing that match the city's reality.",
-  },
-  {
-    title: 'Transparent booking',
-    description:
-      'Clear pricing per session, per class, or per day. No hidden fees, no surprises at checkout.',
-  },
-];
-
-export function Features() {
+export function FeaturesSection({ content }: FeaturesSectionProps) {
   return (
     <section
       id="features"
@@ -31,15 +14,14 @@ export function Features() {
       <div className="mx-auto max-w-5xl px-6 py-20 sm:py-24">
         <div className="text-center">
           <h2 className="text-3xl font-bold tracking-tight text-ink-900 sm:text-4xl">
-            Why Siu Tin Dei
+            {content.title}
           </h2>
           <p className="mx-auto mt-4 max-w-2xl text-lg text-ink-700">
-            A focused starting point for parents searching for the right
-            activities for their kids.
+            {content.description}
           </p>
         </div>
         <ul className="mt-12 grid gap-8 sm:grid-cols-3">
-          {FEATURES.map((feature) => (
+          {content.items.map((feature) => (
             <li
               key={feature.title}
               className="rounded-xl border border-brand-100 bg-brand-50 p-6"

--- a/apps/public_www/src/components/sections/grid/hero-section.tsx
+++ b/apps/public_www/src/components/sections/grid/hero-section.tsx
@@ -1,7 +1,25 @@
-import { getSiteConfig } from '@/lib/site-config';
+import type { HeroContent, Locale } from '@/content';
+import { localizeHref } from '@/lib/locale-routing';
 
-export function Hero() {
-  const { siteName, siteTagline } = getSiteConfig();
+interface HeroSectionProps {
+  readonly locale: Locale;
+  readonly content: HeroContent;
+  readonly eyebrow: string;
+  readonly primaryCtaLabel: string;
+  readonly primaryCtaHref: string;
+  readonly secondaryCtaLabel: string;
+  readonly secondaryCtaHref: string;
+}
+
+export function HeroSection({
+  locale,
+  content,
+  eyebrow,
+  primaryCtaLabel,
+  primaryCtaHref,
+  secondaryCtaLabel,
+  secondaryCtaHref,
+}: HeroSectionProps) {
   return (
     <section
       id="hero"
@@ -10,26 +28,26 @@ export function Hero() {
     >
       <div className="mx-auto max-w-5xl px-6 py-24 text-center sm:py-32">
         <p className="text-sm font-semibold uppercase tracking-widest text-brand-100">
-          Coming soon
+          {eyebrow}
         </p>
         <h1 className="mt-4 text-4xl font-bold tracking-tight sm:text-6xl">
-          {siteName}
+          {content.title}
         </h1>
         <p className="mx-auto mt-6 max-w-2xl text-lg text-brand-100">
-          {siteTagline}
+          {content.subtitle}
         </p>
         <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
           <a
-            href="#features"
+            href={localizeHref(primaryCtaHref, locale)}
             className="rounded-full bg-white px-6 py-3 font-semibold text-brand-700 shadow-sm transition hover:bg-brand-50"
           >
-            Learn more
+            {primaryCtaLabel}
           </a>
           <a
-            href="#contact"
+            href={localizeHref(secondaryCtaHref, locale)}
             className="rounded-full border border-white px-6 py-3 font-semibold text-white transition hover:bg-white/10"
           >
-            Get in touch
+            {secondaryCtaLabel}
           </a>
         </div>
       </div>

--- a/apps/public_www/src/components/sections/grid/page-body-grid.tsx
+++ b/apps/public_www/src/components/sections/grid/page-body-grid.tsx
@@ -1,0 +1,113 @@
+import type { Locale, SiteContent } from '@/content';
+import { FeaturesSection } from '@/components/sections/grid/features-section';
+import { HeroSection } from '@/components/sections/grid/hero-section';
+import { RichTextSection } from '@/components/sections/grid/rich-text-section';
+import type {
+  PageBodyGridConfig,
+  PageGridCellConfig,
+  PageGridComponentId,
+} from '@/lib/page-grid/types';
+import { PAGE_GRID_COMPONENT_IDS } from '@/lib/page-grid/types';
+import { validatePageBodyGrid } from '@/lib/page-grid/validate-grid';
+
+interface PageBodyGridProps {
+  readonly locale: Locale;
+  readonly content: SiteContent;
+  readonly body: PageBodyGridConfig;
+}
+
+function readStringProp(
+  props: Record<string, unknown> | undefined,
+  key: string,
+  fallback: string,
+): string {
+  const value = props?.[key];
+  return typeof value === 'string' && value.trim() !== '' ? value : fallback;
+}
+
+function readStringArrayProp(
+  props: Record<string, unknown> | undefined,
+  key: string,
+): readonly string[] {
+  const value = props?.[key];
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((item): item is string => typeof item === 'string');
+}
+
+function isPageGridComponentId(value: string): value is PageGridComponentId {
+  return (PAGE_GRID_COMPONENT_IDS as readonly string[]).includes(value);
+}
+
+function renderGridCell(
+  locale: Locale,
+  content: SiteContent,
+  cell: PageGridCellConfig,
+) {
+  const props = cell.props;
+
+  if (!isPageGridComponentId(cell.component)) {
+    return null;
+  }
+
+  switch (cell.component) {
+    case 'hero':
+      return (
+        <HeroSection
+          locale={locale}
+          content={content.hero}
+          eyebrow={readStringProp(props, 'eyebrow', '')}
+          primaryCtaLabel={readStringProp(props, 'primaryCtaLabel', '')}
+          primaryCtaHref={readStringProp(props, 'primaryCtaHref', '/')}
+          secondaryCtaLabel={readStringProp(props, 'secondaryCtaLabel', '')}
+          secondaryCtaHref={readStringProp(props, 'secondaryCtaHref', '#contact')}
+        />
+      );
+    case 'features':
+      return <FeaturesSection content={content.features} />;
+    case 'richText':
+      return (
+        <RichTextSection
+          title={readStringProp(props, 'title', '')}
+          paragraphs={readStringArrayProp(props, 'paragraphs')}
+        />
+      );
+    default:
+      return null;
+  }
+}
+
+export function PageBodyGrid({ locale, content, body }: PageBodyGridProps) {
+  validatePageBodyGrid(body);
+
+  return (
+    <div className="page-body-grid">
+      {body.rows.map((row, rowIndex) => (
+        <div
+          key={`page-grid-row-${rowIndex}`}
+          className="page-body-grid__row mx-auto grid max-w-7xl grid-cols-12 gap-x-4 gap-y-0 px-4 sm:px-6 lg:px-8"
+        >
+          {row.cells.map((cell, cellIndex) => {
+            const colStart = cell.colStart ?? 1;
+            const colSpan = cell.colSpan;
+            const columnClass = `col-[${colStart}_/span_${colSpan}]`;
+
+            return (
+              <div
+                key={`page-grid-cell-${rowIndex}-${cellIndex}`}
+                className={`page-body-grid__cell min-w-0 ${columnClass}`}
+                data-grid-col-start={colStart}
+                data-grid-col-span={colSpan}
+                data-component={cell.component}
+              >
+                {renderGridCell(locale, content, cell)}
+              </div>
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/public_www/src/components/sections/grid/rich-text-section.tsx
+++ b/apps/public_www/src/components/sections/grid/rich-text-section.tsx
@@ -1,0 +1,21 @@
+interface RichTextSectionProps {
+  readonly title: string;
+  readonly paragraphs: readonly string[];
+}
+
+export function RichTextSection({ title, paragraphs }: RichTextSectionProps) {
+  return (
+    <section className="bg-white" data-section-id="rich-text">
+      <div className="mx-auto max-w-3xl px-6 py-16 sm:py-20">
+        <h2 className="text-3xl font-bold tracking-tight text-ink-900">
+          {title}
+        </h2>
+        <div className="mt-6 space-y-4 text-lg leading-8 text-ink-700">
+          {paragraphs.map((paragraph) => (
+            <p key={paragraph}>{paragraph}</p>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/public_www/src/components/sections/navbar.tsx
+++ b/apps/public_www/src/components/sections/navbar.tsx
@@ -1,0 +1,70 @@
+import Link from 'next/link';
+
+import {
+  isValidLocale,
+  type Locale,
+  type NavbarContent,
+} from '@/content';
+import { localizeHref } from '@/lib/locale-routing';
+import { ROUTES } from '@/lib/routes';
+
+interface NavbarProps {
+  readonly locale: Locale;
+  readonly content: NavbarContent;
+  readonly currentPath?: string;
+}
+
+export function Navbar({ locale, content, currentPath = ROUTES.home }: NavbarProps) {
+  return (
+    <header className="border-b border-brand-100 bg-white">
+      <div className="mx-auto flex max-w-7xl items-center justify-between gap-6 px-4 py-4 sm:px-6 lg:px-8">
+        <Link
+          href={localizeHref(ROUTES.home, locale)}
+          className="text-lg font-bold text-brand-700"
+        >
+          {content.brand}
+        </Link>
+        <nav
+          className="hidden items-center gap-6 text-sm font-medium text-ink-700 md:flex"
+          aria-label="Main"
+        >
+          {content.menuItems.map((item) => (
+            <Link
+              key={item.href}
+              href={localizeHref(item.href, locale)}
+              className="transition hover:text-brand-600"
+            >
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+        <div
+          className="flex items-center gap-2"
+          role="navigation"
+          aria-label={content.languageSelector.menuAriaLabel}
+        >
+          {content.languageSelector.options.map((option) => {
+            if (!isValidLocale(option.locale)) {
+              return null;
+            }
+
+            return (
+            <Link
+              key={option.locale}
+              href={localizeHref(currentPath, option.locale)}
+              className={`rounded-md px-2 py-1 text-xs font-semibold uppercase tracking-wide ${
+                option.locale === locale
+                  ? 'bg-brand-500 text-white'
+                  : 'text-ink-700 hover:bg-brand-50'
+              }`}
+              aria-current={option.locale === locale ? 'page' : undefined}
+            >
+              {option.shortLabel}
+            </Link>
+            );
+          })}
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/apps/public_www/src/components/shared/google-tag-manager.tsx
+++ b/apps/public_www/src/components/shared/google-tag-manager.tsx
@@ -1,0 +1,10 @@
+const GTM_SCRIPT_PATH = '/scripts/init-gtm.js';
+
+export function GoogleTagManager() {
+  const gtmId = process.env.NEXT_PUBLIC_GTM_ID;
+  if (!gtmId) {
+    return null;
+  }
+
+  return <script src={GTM_SCRIPT_PATH} async />;
+}

--- a/apps/public_www/src/components/shared/meta-pixel.tsx
+++ b/apps/public_www/src/components/shared/meta-pixel.tsx
@@ -1,0 +1,10 @@
+const META_PIXEL_SCRIPT_PATH = '/scripts/init-meta-pixel.js';
+
+export function MetaPixel() {
+  const pixelId = process.env.NEXT_PUBLIC_META_PIXEL_ID;
+  if (!pixelId) {
+    return null;
+  }
+
+  return <script src={META_PIXEL_SCRIPT_PATH} async />;
+}

--- a/apps/public_www/src/components/shared/page-layout.tsx
+++ b/apps/public_www/src/components/shared/page-layout.tsx
@@ -1,13 +1,45 @@
 import type { ReactNode } from 'react';
 
+import type { FooterContent, Locale, NavbarContent } from '@/content';
+import { Footer } from '@/components/sections/footer';
+import { Navbar } from '@/components/sections/navbar';
+
 interface PageLayoutProps {
+  readonly locale: Locale;
+  readonly navbarContent: NavbarContent;
+  readonly footerContent: FooterContent;
+  readonly currentPath?: string;
   readonly children: ReactNode;
+  readonly mainClassName?: string;
+  readonly mainId?: string;
 }
 
-export function PageLayout({ children }: PageLayoutProps) {
+const DEFAULT_MAIN_CLASSNAME = 'min-h-screen flex-1';
+
+export function PageLayout({
+  locale,
+  navbarContent,
+  footerContent,
+  currentPath,
+  children,
+  mainClassName,
+  mainId = 'main-content',
+}: PageLayoutProps) {
   return (
     <div className="flex min-h-screen flex-col">
-      <main className="flex-1">{children}</main>
+      <Navbar
+        locale={locale}
+        content={navbarContent}
+        currentPath={currentPath}
+      />
+      <main
+        id={mainId}
+        tabIndex={-1}
+        className={mainClassName ?? DEFAULT_MAIN_CLASSNAME}
+      >
+        {children}
+      </main>
+      <Footer content={footerContent} />
     </div>
   );
 }

--- a/apps/public_www/src/content/content-field-utils.ts
+++ b/apps/public_www/src/content/content-field-utils.ts
@@ -1,0 +1,15 @@
+/**
+ * Replaces `{key}` placeholders in copy templates (evolvesprouts pattern).
+ */
+export function formatContentTemplate(
+  template: string,
+  values: Record<string, string | number>,
+): string {
+  return template.replace(/\{(\w+)\}/g, (match, key: string) => {
+    const value = values[key];
+    if (value === undefined) {
+      return match;
+    }
+    return String(value);
+  });
+}

--- a/apps/public_www/src/content/en.json
+++ b/apps/public_www/src/content/en.json
@@ -1,0 +1,147 @@
+{
+  "meta": {
+    "locale": "en",
+    "direction": "ltr",
+    "label": "English"
+  },
+  "navbar": {
+    "brand": "Siu Tin Dei",
+    "menuItems": [
+      { "label": "Home", "href": "/" },
+      { "label": "About", "href": "/about" }
+    ],
+    "languageSelector": {
+      "menuAriaLabel": "Select language",
+      "options": [
+        { "locale": "en", "label": "English", "shortLabel": "EN" },
+        { "locale": "zh-HK", "label": "繁體中文", "shortLabel": "TC" }
+      ]
+    },
+    "openNavigationMenuAriaLabel": "Open navigation menu",
+    "closeNavigationMenuAriaLabel": "Close navigation menu"
+  },
+  "footer": {
+    "tagline": "An LX Software product. Hong Kong, SAR.",
+    "copyrightTemplate": "© {year} LX Software Limited. All rights reserved.",
+    "contactHeading": "Contact"
+  },
+  "seo": {
+    "fallbackTitle": "Siu Tin Dei | Children's activities in Hong Kong",
+    "fallbackDescription": "Discover curated children's activities in Hong Kong with Siu Tin Dei.",
+    "defaultSocialImage": "/images/seo/siutindei-og-default.png",
+    "defaultSocialImageAlt": "Siu Tin Dei children's activities in Hong Kong",
+    "home": {
+      "title": "Siu Tin Dei | Children's activities in Hong Kong",
+      "description": "Discover curated children's activities in Hong Kong with Siu Tin Dei."
+    },
+    "about": {
+      "title": "About Siu Tin Dei",
+      "description": "Learn how Siu Tin Dei helps Hong Kong families find trusted children's activities."
+    }
+  },
+  "common": {
+    "shell": {
+      "skipToMainContentLabel": "Skip to main content",
+      "environmentBadgeLabel": "Staging",
+      "noscript": {
+        "title": "JavaScript is disabled",
+        "description": "Core navigation still works. Enable JavaScript for the full experience.",
+        "homeLabel": "Home",
+        "contactLabel": "Contact"
+      }
+    }
+  },
+  "pages": {
+    "home": {
+      "body": {
+        "rows": [
+          {
+            "cells": [
+              {
+                "component": "hero",
+                "colStart": 1,
+                "colSpan": 12,
+                "props": {
+                  "eyebrow": "Coming soon",
+                  "primaryCtaLabel": "Learn more",
+                  "primaryCtaHref": "#features",
+                  "secondaryCtaLabel": "Get in touch",
+                  "secondaryCtaHref": "#contact"
+                }
+              }
+            ]
+          },
+          {
+            "cells": [
+              {
+                "component": "features",
+                "colStart": 1,
+                "colSpan": 12
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "about": {
+      "body": {
+        "rows": [
+          {
+            "cells": [
+              {
+                "component": "hero",
+                "colStart": 1,
+                "colSpan": 12,
+                "props": {
+                  "eyebrow": "About us",
+                  "primaryCtaLabel": "Explore activities",
+                  "primaryCtaHref": "/",
+                  "secondaryCtaLabel": "Contact",
+                  "secondaryCtaHref": "#contact"
+                }
+              }
+            ]
+          },
+          {
+            "cells": [
+              {
+                "component": "richText",
+                "colStart": 2,
+                "colSpan": 10,
+                "props": {
+                  "title": "Built for Hong Kong families",
+                  "paragraphs": [
+                    "Siu Tin Dei helps parents discover vetted children's activities across Hong Kong — with transparent schedules, pricing, and locations.",
+                    "We are starting with a focused catalogue and will expand as partner programmes join the platform."
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "hero": {
+    "title": "Siu Tin Dei",
+    "subtitle": "Curated children's activities in Hong Kong."
+  },
+  "features": {
+    "title": "Why Siu Tin Dei",
+    "description": "A focused starting point for parents searching for the right activities for their kids.",
+    "items": [
+      {
+        "title": "Vetted programs",
+        "description": "Every activity is reviewed for safety, value, and pedagogical quality."
+      },
+      {
+        "title": "Hong Kong focused",
+        "description": "Districts, languages, schedules, and pricing that match the city's reality."
+      },
+      {
+        "title": "Transparent booking",
+        "description": "Clear pricing per session, per class, or per day — no surprises at checkout."
+      }
+    ]
+  }
+}

--- a/apps/public_www/src/content/index.ts
+++ b/apps/public_www/src/content/index.ts
@@ -1,0 +1,34 @@
+import enContent from './en.json';
+import zhHKContent from './zh-HK.json';
+
+export const SUPPORTED_LOCALES = ['en', 'zh-HK'] as const;
+export type Locale = (typeof SUPPORTED_LOCALES)[number];
+export const DEFAULT_LOCALE: Locale = 'en';
+
+type BaseSiteContent = typeof enContent;
+export type SiteContent = BaseSiteContent;
+
+export type NavbarContent = SiteContent['navbar'];
+export type FooterContent = SiteContent['footer'];
+export type HeroContent = SiteContent['hero'];
+export type FeaturesContent = SiteContent['features'];
+export type PageBodyConfig = SiteContent['pages'][keyof SiteContent['pages']]['body'];
+export type PageBodyGridConfig = PageBodyConfig;
+export type PageKey = keyof SiteContent['pages'];
+
+const contentMap = {
+  en: enContent,
+  'zh-HK': zhHKContent,
+} satisfies Record<Locale, BaseSiteContent>;
+
+export function getContent(locale: string): SiteContent {
+  if (isValidLocale(locale)) {
+    return contentMap[locale];
+  }
+
+  return contentMap[DEFAULT_LOCALE];
+}
+
+export function isValidLocale(value: string): value is Locale {
+  return (SUPPORTED_LOCALES as readonly string[]).includes(value);
+}

--- a/apps/public_www/src/content/zh-HK.json
+++ b/apps/public_www/src/content/zh-HK.json
@@ -1,0 +1,147 @@
+{
+  "meta": {
+    "locale": "zh-HK",
+    "direction": "ltr",
+    "label": "繁體中文"
+  },
+  "navbar": {
+    "brand": "Siu Tin Dei",
+    "menuItems": [
+      { "label": "主頁", "href": "/" },
+      { "label": "關於我們", "href": "/about" }
+    ],
+    "languageSelector": {
+      "menuAriaLabel": "選擇語言",
+      "options": [
+        { "locale": "en", "label": "English", "shortLabel": "EN" },
+        { "locale": "zh-HK", "label": "繁體中文", "shortLabel": "TC" }
+      ]
+    },
+    "openNavigationMenuAriaLabel": "開啟導覽選單",
+    "closeNavigationMenuAriaLabel": "關閉導覽選單"
+  },
+  "footer": {
+    "tagline": "LX Software 產品。香港特別行政區。",
+    "copyrightTemplate": "© {year} LX Software Limited. 版權所有。",
+    "contactHeading": "聯絡我們"
+  },
+  "seo": {
+    "fallbackTitle": "Siu Tin Dei | 香港兒童活動",
+    "fallbackDescription": "透過 Siu Tin Dei 發掘香港精選兒童活動。",
+    "defaultSocialImage": "/images/seo/siutindei-og-default.png",
+    "defaultSocialImageAlt": "Siu Tin Dei 香港兒童活動",
+    "home": {
+      "title": "Siu Tin Dei | 香港兒童活動",
+      "description": "透過 Siu Tin Dei 發掘香港精選兒童活動。"
+    },
+    "about": {
+      "title": "關於 Siu Tin Dei",
+      "description": "了解 Siu Tin Dei 如何協助香港家庭找到可信賴的兒童活動。"
+    }
+  },
+  "common": {
+    "shell": {
+      "skipToMainContentLabel": "跳至主要內容",
+      "environmentBadgeLabel": "測試環境",
+      "noscript": {
+        "title": "已停用 JavaScript",
+        "description": "基本導覽仍可使用。啟用 JavaScript 以獲得完整體驗。",
+        "homeLabel": "主頁",
+        "contactLabel": "聯絡"
+      }
+    }
+  },
+  "pages": {
+    "home": {
+      "body": {
+        "rows": [
+          {
+            "cells": [
+              {
+                "component": "hero",
+                "colStart": 1,
+                "colSpan": 12,
+                "props": {
+                  "eyebrow": "即將推出",
+                  "primaryCtaLabel": "了解更多",
+                  "primaryCtaHref": "#features",
+                  "secondaryCtaLabel": "聯絡我們",
+                  "secondaryCtaHref": "#contact"
+                }
+              }
+            ]
+          },
+          {
+            "cells": [
+              {
+                "component": "features",
+                "colStart": 1,
+                "colSpan": 12
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "about": {
+      "body": {
+        "rows": [
+          {
+            "cells": [
+              {
+                "component": "hero",
+                "colStart": 1,
+                "colSpan": 12,
+                "props": {
+                  "eyebrow": "關於我們",
+                  "primaryCtaLabel": "瀏覽活動",
+                  "primaryCtaHref": "/",
+                  "secondaryCtaLabel": "聯絡",
+                  "secondaryCtaHref": "#contact"
+                }
+              }
+            ]
+          },
+          {
+            "cells": [
+              {
+                "component": "richText",
+                "colStart": 2,
+                "colSpan": 10,
+                "props": {
+                  "title": "為香港家庭而設",
+                  "paragraphs": [
+                    "Siu Tin Dei 協助家長發掘香港各地經審核的兒童活動，日程、收費及地點一目了然。",
+                    "我們先推出精選目錄，並會隨合作機構加入而逐步擴充。"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "hero": {
+    "title": "Siu Tin Dei",
+    "subtitle": "香港精選兒童活動。"
+  },
+  "features": {
+    "title": "為何選擇 Siu Tin Dei",
+    "description": "為尋找合適兒童活動的家長而設的起點。",
+    "items": [
+      {
+        "title": "嚴選課程",
+        "description": "每項活動均經團隊審核，確保安全、價值及教學質素。"
+      },
+      {
+        "title": "聚焦香港",
+        "description": "地區、語言、時間表及收費切合本地需要。"
+      },
+      {
+        "title": "收費透明",
+        "description": "按節、按班或按日清晰標價，結帳無隱藏費用。"
+      }
+    ]
+  }
+}

--- a/apps/public_www/src/lib/locale-page.ts
+++ b/apps/public_www/src/lib/locale-page.ts
@@ -1,0 +1,38 @@
+import { notFound } from 'next/navigation';
+
+import {
+  getContent,
+  isValidLocale,
+  SUPPORTED_LOCALES,
+  type Locale,
+  type SiteContent,
+} from '@/content';
+
+export type LocaleRouteParams = Promise<{ locale: string }>;
+
+export interface LocaleRouteProps {
+  params: LocaleRouteParams;
+}
+
+export interface LocalePageContext {
+  locale: Locale;
+  content: SiteContent;
+}
+
+export async function resolveLocalePageContext(
+  params: LocaleRouteParams,
+): Promise<LocalePageContext> {
+  const { locale } = await params;
+  if (!isValidLocale(locale)) {
+    notFound();
+  }
+
+  return {
+    locale,
+    content: getContent(locale),
+  };
+}
+
+export function generateLocaleStaticParams() {
+  return SUPPORTED_LOCALES.map((locale) => ({ locale }));
+}

--- a/apps/public_www/src/lib/locale-routing.ts
+++ b/apps/public_www/src/lib/locale-routing.ts
@@ -1,0 +1,82 @@
+import {
+  DEFAULT_LOCALE,
+  isValidLocale,
+  type Locale,
+} from '@/content';
+import { getHrefKind, isExternalHref } from '@/lib/url-utils';
+
+function sanitizePath(path: string): string {
+  let value = path.trim();
+
+  if (value === '' || value === '#') {
+    return value || '/';
+  }
+
+  if (/^https?:\/\//i.test(value)) {
+    try {
+      value = new URL(value).pathname;
+    } catch {
+      return value;
+    }
+  }
+
+  value = value.split('#')[0] ?? value;
+  value = value.split('?')[0] ?? value;
+
+  if (!value.startsWith('/')) {
+    value = `/${value}`;
+  }
+
+  return value.replace(/\/+$/, '') || '/';
+}
+
+export function getLocaleFromPath(path: string): Locale {
+  const segments = sanitizePath(path).split('/').filter(Boolean);
+  if (segments.length > 0 && isValidLocale(segments[0])) {
+    return segments[0];
+  }
+
+  return DEFAULT_LOCALE;
+}
+
+export function normalizeLocalizedPath(path: string): string {
+  let value = sanitizePath(path);
+  const segments = value.split('/').filter(Boolean);
+
+  if (segments.length > 0 && isValidLocale(segments[0])) {
+    const localizedValue = `/${segments.slice(1).join('/')}`;
+    value = localizedValue === '/' ? '/' : localizedValue;
+  }
+
+  return value || '/';
+}
+
+export function localizePath(path: string, locale: Locale): string {
+  const basePath = normalizeLocalizedPath(path);
+  return basePath === '/' ? `/${locale}/` : `/${locale}${basePath}/`;
+}
+
+export function localizeHref(href: string, locale: Locale): string {
+  const value = href.trim();
+  if (value === '' || value === '#') {
+    return value || '/';
+  }
+
+  if (getHrefKind(value) === 'unsafe') {
+    return value;
+  }
+
+  if (isExternalHref(value)) {
+    return value;
+  }
+
+  const hashIndex = value.indexOf('#');
+  const hashValue = hashIndex >= 0 ? value.slice(hashIndex) : '';
+  const withoutHash = hashIndex >= 0 ? value.slice(0, hashIndex) : value;
+  const queryIndex = withoutHash.indexOf('?');
+  const queryValue = queryIndex >= 0 ? withoutHash.slice(queryIndex) : '';
+  const pathnameValue =
+    queryIndex >= 0 ? withoutHash.slice(0, queryIndex) : withoutHash;
+
+  return `${localizePath(pathnameValue || '/', locale)}${queryValue}${hashValue}`;
+}

--- a/apps/public_www/src/lib/page-grid/types.ts
+++ b/apps/public_www/src/lib/page-grid/types.ts
@@ -1,0 +1,24 @@
+export const PAGE_GRID_MAX_COLUMNS = 12;
+
+export const PAGE_GRID_COMPONENT_IDS = [
+  'hero',
+  'features',
+  'richText',
+] as const;
+
+export type PageGridComponentId = (typeof PAGE_GRID_COMPONENT_IDS)[number];
+
+export interface PageGridCellConfig {
+  readonly component: string;
+  readonly colStart?: number;
+  readonly colSpan: number;
+  readonly props?: Record<string, unknown>;
+}
+
+export interface PageGridRowConfig {
+  readonly cells: readonly PageGridCellConfig[];
+}
+
+export interface PageBodyGridConfig {
+  readonly rows: readonly PageGridRowConfig[];
+}

--- a/apps/public_www/src/lib/page-grid/validate-grid.ts
+++ b/apps/public_www/src/lib/page-grid/validate-grid.ts
@@ -1,0 +1,41 @@
+import { PAGE_GRID_MAX_COLUMNS, type PageBodyGridConfig } from './types';
+
+export function validatePageBodyGrid(body: PageBodyGridConfig): void {
+  for (const [rowIndex, row] of body.rows.entries()) {
+    if (row.cells.length === 0) {
+      throw new Error(`Page grid row ${rowIndex} has no cells.`);
+    }
+
+    let occupiedColumns = 0;
+    for (const [cellIndex, cell] of row.cells.entries()) {
+      const colStart = cell.colStart ?? 1;
+      const colSpan = cell.colSpan;
+
+      if (colStart < 1 || colStart > PAGE_GRID_MAX_COLUMNS) {
+        throw new Error(
+          `Row ${rowIndex} cell ${cellIndex}: colStart must be 1–${PAGE_GRID_MAX_COLUMNS}.`,
+        );
+      }
+
+      if (colSpan < 1 || colSpan > PAGE_GRID_MAX_COLUMNS) {
+        throw new Error(
+          `Row ${rowIndex} cell ${cellIndex}: colSpan must be 1–${PAGE_GRID_MAX_COLUMNS}.`,
+        );
+      }
+
+      if (colStart + colSpan - 1 > PAGE_GRID_MAX_COLUMNS) {
+        throw new Error(
+          `Row ${rowIndex} cell ${cellIndex}: cell exceeds the ${PAGE_GRID_MAX_COLUMNS}-column grid.`,
+        );
+      }
+
+      occupiedColumns += colSpan;
+    }
+
+    if (occupiedColumns > PAGE_GRID_MAX_COLUMNS) {
+      throw new Error(
+        `Row ${rowIndex}: total colSpan (${occupiedColumns}) exceeds ${PAGE_GRID_MAX_COLUMNS}.`,
+      );
+    }
+  }
+}

--- a/apps/public_www/src/lib/routes.ts
+++ b/apps/public_www/src/lib/routes.ts
@@ -1,0 +1,11 @@
+export const ROUTES = {
+  home: '/',
+  about: '/about',
+} as const;
+
+export type AppRoutePath = (typeof ROUTES)[keyof typeof ROUTES];
+
+export const INDEXED_ROUTE_PATHS: readonly AppRoutePath[] = [
+  ROUTES.home,
+  ROUTES.about,
+];

--- a/apps/public_www/src/lib/seo.ts
+++ b/apps/public_www/src/lib/seo.ts
@@ -1,0 +1,198 @@
+import type { Metadata } from 'next';
+
+import {
+  DEFAULT_LOCALE,
+  SUPPORTED_LOCALES,
+  type Locale,
+} from '@/content';
+import {
+  localizePath as localizeLocalizedPath,
+  normalizeLocalizedPath,
+} from '@/lib/locale-routing';
+
+const SITE_ORIGIN_ENV_NAME = 'NEXT_PUBLIC_SITE_ORIGIN';
+let cachedSiteOrigin: string | undefined;
+let cachedSiteHost: string | undefined;
+
+export function normalizeSiteOrigin(rawOrigin: string): string {
+  const normalizedOrigin = rawOrigin.trim();
+  if (normalizedOrigin === '') {
+    throw new Error(`${SITE_ORIGIN_ENV_NAME} must not be empty.`);
+  }
+
+  let parsedOrigin: URL;
+  try {
+    parsedOrigin = new URL(normalizedOrigin);
+  } catch {
+    throw new Error(`${SITE_ORIGIN_ENV_NAME} must be a valid absolute URL.`);
+  }
+
+  const protocol = parsedOrigin.protocol.toLowerCase();
+  const hostname = parsedOrigin.hostname.toLowerCase();
+  const isLocalhostHttpOrigin =
+    protocol === 'http:' && hostname === 'localhost';
+  if (protocol !== 'https:' && !isLocalhostHttpOrigin) {
+    throw new Error(
+      `${SITE_ORIGIN_ENV_NAME} must use https, or http://localhost for local development.`,
+    );
+  }
+
+  if (
+    parsedOrigin.pathname !== '/'
+    || parsedOrigin.search !== ''
+    || parsedOrigin.hash !== ''
+  ) {
+    throw new Error(
+      `${SITE_ORIGIN_ENV_NAME} must not include a path, query string, or hash fragment.`,
+    );
+  }
+
+  return parsedOrigin.origin;
+}
+
+function resolveSiteOrigin(): string {
+  const configuredSiteOrigin = process.env.NEXT_PUBLIC_SITE_ORIGIN?.trim() ?? '';
+  if (configuredSiteOrigin !== '') {
+    return normalizeSiteOrigin(configuredSiteOrigin);
+  }
+
+  if (process.env.NODE_ENV === 'test') {
+    const locationOrigin =
+      typeof globalThis.location?.origin === 'string'
+        ? globalThis.location.origin.trim()
+        : '';
+    if (locationOrigin !== '') {
+      return normalizeSiteOrigin(locationOrigin);
+    }
+  }
+
+  throw new Error(`Missing required environment variable: ${SITE_ORIGIN_ENV_NAME}`);
+}
+
+export function getSiteOrigin(): string {
+  if (!cachedSiteOrigin) {
+    cachedSiteOrigin = resolveSiteOrigin();
+  }
+
+  return cachedSiteOrigin;
+}
+
+export function getSiteHost(): string {
+  if (!cachedSiteHost) {
+    cachedSiteHost = new URL(getSiteOrigin()).hostname;
+  }
+
+  return cachedSiteHost;
+}
+
+export function _resetSeoCacheForTests(): void {
+  cachedSiteOrigin = undefined;
+  cachedSiteHost = undefined;
+}
+
+export const DEFAULT_SOCIAL_IMAGE = '/images/seo/siutindei-og-default.png';
+export const DEFAULT_SOCIAL_IMAGE_WIDTH = 1200;
+export const DEFAULT_SOCIAL_IMAGE_HEIGHT = 630;
+
+export function localizePath(path: string, locale: Locale): string {
+  return localizeLocalizedPath(path, locale);
+}
+
+export function buildLocaleAlternates(path: string): Record<string, string> {
+  const normalizedPath = normalizeLocalizedPath(path);
+  const languages = Object.fromEntries(
+    SUPPORTED_LOCALES.map((locale) => [
+      locale,
+      localizePath(normalizedPath, locale),
+    ]),
+  );
+
+  return {
+    ...languages,
+    'x-default': localizePath(normalizedPath, DEFAULT_LOCALE),
+  };
+}
+
+interface LocalizedMetadataOptions {
+  locale: Locale;
+  path: string;
+  title: string;
+  description: string;
+  siteName: string;
+  socialImage?: {
+    url: string;
+    alt?: string;
+  };
+  robots?: {
+    index: boolean;
+    follow: boolean;
+  };
+}
+
+function buildPageTitle(title: string, path: string, siteName: string): string {
+  const normalizedTitle = title.trim();
+  if (normalizedTitle === '') {
+    return siteName;
+  }
+
+  if (normalizeLocalizedPath(path) === '/') {
+    return normalizedTitle;
+  }
+
+  const suffix = ` · ${siteName}`;
+  if (normalizedTitle.endsWith(suffix)) {
+    return normalizedTitle;
+  }
+
+  return `${normalizedTitle}${suffix}`;
+}
+
+export function buildLocalizedMetadata({
+  locale,
+  path,
+  title,
+  description,
+  siteName,
+  socialImage,
+  robots,
+}: LocalizedMetadataOptions): Metadata {
+  const localizedPath = localizePath(path, locale);
+  const pageTitle = buildPageTitle(title, path, siteName);
+  const socialImageUrl = socialImage?.url || DEFAULT_SOCIAL_IMAGE;
+  const socialImageAlt = socialImage?.alt || siteName;
+
+  return {
+    title: pageTitle,
+    description,
+    alternates: {
+      canonical: localizedPath,
+      languages: buildLocaleAlternates(path),
+    },
+    openGraph: {
+      title: pageTitle,
+      description,
+      url: localizedPath,
+      siteName,
+      type: 'website',
+      locale,
+      images: [
+        {
+          url: socialImageUrl,
+          alt: socialImageAlt,
+          width: DEFAULT_SOCIAL_IMAGE_WIDTH,
+          height: DEFAULT_SOCIAL_IMAGE_HEIGHT,
+        },
+      ],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: pageTitle,
+      description,
+      images: [socialImageUrl],
+    },
+    robots: {
+      index: robots?.index ?? true,
+      follow: robots?.follow ?? true,
+    },
+  };
+}

--- a/apps/public_www/src/lib/site-config.ts
+++ b/apps/public_www/src/lib/site-config.ts
@@ -12,6 +12,12 @@ export interface SiteConfig {
   readonly contact: SiteContact;
 }
 
+export interface PublicSiteConfig {
+  readonly whatsappUrl?: string;
+  readonly contactEmail?: string;
+  readonly instagramUrl?: string;
+}
+
 function readPublicEnv(name: string): string {
   return (process.env[name] ?? '').trim();
 }
@@ -32,5 +38,17 @@ export function getSiteConfig(): SiteConfig {
       whatsappUrl: readPublicEnv('NEXT_PUBLIC_WHATSAPP_URL'),
       instagramUrl: readPublicEnv('NEXT_PUBLIC_INSTAGRAM_URL'),
     },
+  };
+}
+
+export function resolvePublicSiteConfig(): PublicSiteConfig {
+  const whatsappUrl = readPublicEnv('NEXT_PUBLIC_WHATSAPP_URL');
+  const contactEmail = readPublicEnv('NEXT_PUBLIC_EMAIL');
+  const instagramUrl = readPublicEnv('NEXT_PUBLIC_INSTAGRAM_URL');
+
+  return {
+    ...(whatsappUrl ? { whatsappUrl } : {}),
+    ...(contactEmail ? { contactEmail } : {}),
+    ...(instagramUrl ? { instagramUrl } : {}),
   };
 }

--- a/apps/public_www/src/lib/url-utils.ts
+++ b/apps/public_www/src/lib/url-utils.ts
@@ -1,0 +1,21 @@
+export function isExternalHref(href: string): boolean {
+  const value = href.trim();
+  return /^https?:\/\//i.test(value) || value.startsWith('mailto:');
+}
+
+export function getHrefKind(href: string): 'internal' | 'external' | 'unsafe' {
+  const value = href.trim();
+  if (value === '' || value === '#') {
+    return 'internal';
+  }
+
+  if (/^javascript:/i.test(value)) {
+    return 'unsafe';
+  }
+
+  if (isExternalHref(value)) {
+    return 'external';
+  }
+
+  return 'internal';
+}

--- a/apps/public_www/tests/app/page.test.tsx
+++ b/apps/public_www/tests/app/page.test.tsx
@@ -1,24 +1,28 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
-import HomePage from '@/app/page';
 
-describe('HomePage', () => {
-  it('renders the brand name in the hero', () => {
-    render(<HomePage />);
-    expect(
-      screen.getByRole('heading', { level: 1, name: /siu tin dei/i }),
-    ).toBeInTheDocument();
-  });
+import { MarketingPage } from '@/components/pages/marketing-page';
+import { getContent } from '@/content';
 
-  it('renders the features section', () => {
-    render(<HomePage />);
-    expect(
-      screen.getByRole('heading', { level: 2, name: /why siu tin dei/i }),
-    ).toBeInTheDocument();
-  });
+describe('MarketingPage', () => {
+  it('renders home grid sections from locale content', () => {
+    const content = getContent('en');
 
-  it('renders a footer with copyright', () => {
-    render(<HomePage />);
-    expect(screen.getByText(/all rights reserved/i)).toBeInTheDocument();
+    render(
+      <MarketingPage
+        locale="en"
+        content={content}
+        body={content.pages.home.body}
+        currentPath="/"
+      />,
+    );
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      content.hero.title,
+    );
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
+      content.features.title,
+    );
+    expect(screen.getByRole('navigation', { name: 'Main' })).toBeInTheDocument();
   });
 });

--- a/apps/public_www/tests/lib/locale-routing.test.ts
+++ b/apps/public_www/tests/lib/locale-routing.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { localizeHref, localizePath, normalizeLocalizedPath } from '@/lib/locale-routing';
+
+describe('locale-routing', () => {
+  it('localizes internal paths with trailing slash', () => {
+    expect(localizePath('/about', 'en')).toBe('/en/about/');
+    expect(localizePath('/', 'zh-HK')).toBe('/zh-HK/');
+  });
+
+  it('strips locale prefix when normalizing', () => {
+    expect(normalizeLocalizedPath('/en/about/')).toBe('/about');
+  });
+
+  it('localizes hash and query on internal hrefs', () => {
+    expect(localizeHref('/about#contact', 'zh-HK')).toBe('/zh-HK/about/#contact');
+  });
+});

--- a/apps/public_www/tests/lib/page-grid.test.ts
+++ b/apps/public_www/tests/lib/page-grid.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { validatePageBodyGrid } from '@/lib/page-grid/validate-grid';
+import type { PageBodyGridConfig } from '@/lib/page-grid/types';
+
+describe('validatePageBodyGrid', () => {
+  it('accepts a valid 12-column layout', () => {
+    const body: PageBodyGridConfig = {
+      rows: [
+        {
+          cells: [{ component: 'hero', colStart: 1, colSpan: 12 }],
+        },
+        {
+          cells: [
+            { component: 'richText', colStart: 2, colSpan: 10 },
+          ],
+        },
+      ],
+    };
+
+    expect(() => validatePageBodyGrid(body)).not.toThrow();
+  });
+
+  it('rejects cells that overflow the grid', () => {
+    const body: PageBodyGridConfig = {
+      rows: [
+        {
+          cells: [{ component: 'hero', colStart: 11, colSpan: 4 }],
+        },
+      ],
+    };
+
+    expect(() => validatePageBodyGrid(body)).toThrow(/exceeds/);
+  });
+});

--- a/docs/architecture/public-www.md
+++ b/docs/architecture/public-www.md
@@ -68,6 +68,19 @@ Source: [`apps/public_www`](../../apps/public_www).
 - Lighthouse CI configured at `apps/public_www/.lighthouserc.json`.
 - Build script: `next build` → `inject-csp-meta.mjs` → `validate-csp-meta.mjs`.
 
+### Page composition (evolvesprouts-aligned)
+
+- **Locales:** `src/content/en.json`, `zh-HK.json`, … with routes under
+  `src/app/[locale]/…` and root redirects (`/` → `/en/`).
+- **Template:** `PageLayout` = `Navbar` (header) + `<main>` + `Footer`.
+- **Body:** `pages.<pageKey>.body` defines a 12-column CSS grid (`rows` →
+  `cells` with `component`, `colStart`, `colSpan`, optional `props`). The
+  registry lives in `src/components/sections/grid/page-body-grid.tsx`.
+- **SEO:** `buildLocalizedMetadata` (canonical, hreflang). Optional GTM /
+  Meta Pixel via `NEXT_PUBLIC_GTM_ID` / `NEXT_PUBLIC_META_PIXEL_ID` and
+  host allow-lists; CSP `script-src` / `connect-src` extended at build time
+  when those env vars are set (`scripts/inject-csp-meta.mjs`).
+
 The build is deliberately **gated** by:
 
 | Script | Purpose |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the **static locale redirect fix** on top of the evolvesprouts-style public site work already merged to `main` (#302).

## Merge with main

Resolved conflicts in:

- `apps/public_www/src/app/page.tsx`
- `apps/public_www/src/app/about/page.tsx`

`main` still had `redirect()` from `next/navigation` (blank page on S3/CloudFront at `/`). This branch keeps `StaticLocaleRedirect` + `redirect:inject` meta refresh.

## What this PR adds beyond #302

- `StaticLocaleRedirect` client fallback + visible link
- `scripts/inject-static-redirects.mjs` (build step)
- `redirect:inject` in `package.json` build pipeline

## Verification

- Merged `origin/main` cleanly after conflict resolution
- `npm run typecheck` and `npm run test` pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f2e97209-e4d7-47a7-aa62-d8d1d468d31f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2e97209-e4d7-47a7-aa62-d8d1d468d31f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

