### PR TITLE
fix(infra): resolve brace-expansion security advisory for Dependabot

### DIFF
--- a/backend/infrastructure/package-lock.json
+++ b/backend/infrastructure/package-lock.json
@@ -252,16 +252,6 @@
         "@aws-cdk/cloud-assembly-schema": ">=53.21.0"
       }
     },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
-      "integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
       "version": "1.0.2",
       "inBundle": true,
@@ -321,7 +311,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.5",
+      "version": "5.0.6",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -584,9 +574,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/backend/infrastructure/package.json
+++ b/backend/infrastructure/package.json
@@ -25,5 +25,8 @@
     "aws-cdk": "^2.1122.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3"
+  },
+  "overrides": {
+    "brace-expansion": "5.0.6"
   }
 }

--- a/backend/infrastructure/scripts/patch-bundled-minimatch.js
+++ b/backend/infrastructure/scripts/patch-bundled-minimatch.js
@@ -1,39 +1,53 @@
 /**
- * Patches the vulnerable bundled minimatch inside aws-cdk-lib with the
- * top-level minimatch dependency (10.2.4+) that includes security fixes
- * for GHSA-7r86-cg39-jmmj and GHSA-23c5-xmqv-rm74.
+ * Patches vulnerable bundled minimatch and brace-expansion inside
+ * aws-cdk-lib with the top-level dependencies that include security fixes
+ * for GHSA-7r86-cg39-jmmj, GHSA-23c5-xmqv-rm74, and brace-expansion
+ * ReDoS advisories (e.g. GHSA-v6mv-4v72-8cf6).
  *
- * aws-cdk-lib bundles minimatch in its tarball, so npm overrides cannot
- * replace it. This postinstall script copies the patched copy over the
- * bundled one after every install.
+ * aws-cdk-lib bundles these packages in its tarball, so npm overrides cannot
+ * replace them. This postinstall script copies the patched copies over the
+ * bundled ones after every install.
  */
 
 const fs = require('fs');
 const path = require('path');
 
-const source = path.join(__dirname, '..', 'node_modules', 'minimatch');
-const target = path.join(
-  __dirname,
-  '..',
+const infraRoot = path.join(__dirname, '..');
+const cdkBundledRoot = path.join(
+  infraRoot,
   'node_modules',
   'aws-cdk-lib',
   'node_modules',
-  'minimatch',
 );
 
-if (!fs.existsSync(source)) {
-  console.warn('[patch-bundled-minimatch] source not found, skipping');
-  process.exit(0);
+const patches = [
+  {
+    name: 'minimatch',
+    source: path.join(infraRoot, 'node_modules', 'minimatch'),
+    target: path.join(cdkBundledRoot, 'minimatch'),
+  },
+  {
+    name: 'brace-expansion',
+    source: path.join(infraRoot, 'node_modules', 'brace-expansion'),
+    target: path.join(cdkBundledRoot, 'brace-expansion'),
+  },
+];
+
+for (const { name, source, target } of patches) {
+  if (!fs.existsSync(source)) {
+    console.warn(`[patch-bundled-deps] ${name} source not found, skipping`);
+    continue;
+  }
+
+  if (!fs.existsSync(target)) {
+    console.warn(`[patch-bundled-deps] ${name} target not found, skipping`);
+    continue;
+  }
+
+  fs.cpSync(source, target, { recursive: true });
+
+  const patchedVersion = require(path.join(target, 'package.json')).version;
+  console.log(
+    `[patch-bundled-deps] replaced bundled ${name} with ${patchedVersion}`,
+  );
 }
-
-if (!fs.existsSync(target)) {
-  console.warn('[patch-bundled-minimatch] target not found, skipping');
-  process.exit(0);
-}
-
-fs.cpSync(source, target, { recursive: true });
-
-const patchedVersion = require(path.join(target, 'package.json')).version;
-console.log(
-  `[patch-bundled-minimatch] replaced bundled minimatch with ${patchedVersion}`,
-);

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -253,8 +253,9 @@ Lambdas or NAT Gateway.
 - Weekly schedule (Mondays) to reduce PR noise.
 - Dependencies grouped by category (AWS CDK, Firebase, database, etc.).
 - Major version updates ignored to require manual review.
-- `brace-expansion` is ignored in `/backend/infrastructure` because
-  `aws-cdk-lib` bundles it; `postinstall` patches the bundled copy.
+- `brace-expansion` in `/backend/infrastructure` is pinned with npm
+  `overrides` and copied into `aws-cdk-lib` by `postinstall` (same pattern
+  as bundled `minimatch`) because Dependabot cannot patch in-bundle deps.
 - PRs labeled by ecosystem (`dependencies`, `ci`, `backend`, `mobile`, `infrastructure`).
 
 **Dependabot commands:**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Dependabot security updates for `brace-expansion` in `/backend/infrastructure` failed with `security_update_not_possible` because `aws-cdk-lib` bundles vulnerable `5.0.5` and npm cannot override in-bundle dependencies.

## Changes

- Add npm `overrides` to pin `brace-expansion` to `5.0.6` (patched release).
- Extend the existing `postinstall` patch script to copy the top-level `brace-expansion` into `aws-cdk-lib/node_modules` (same approach as bundled `minimatch`).
- Update `package-lock.json` so the resolved top-level dependency is `5.0.6`.
- Refresh architecture decision notes for the override + postinstall pattern.

## Verification

- `npm install` in `backend/infrastructure` — postinstall patches both packages; `npm audit` reports 0 vulnerabilities.
- `npm run build` — TypeScript compile succeeds.

## Notes

The `GITHUB_REGISTRIES_PROXY` parse warning in Dependabot logs is a known upstream noise item and is unrelated to this failure.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce2cb125-f7fa-4269-b031-888ead26b5ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce2cb125-f7fa-4269-b031-888ead26b5ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

