### PR TITLE
feat(public-www): mobile-first navigation and shared site chrome

### DIFF
--- a/apps/public_www/README.md
+++ b/apps/public_www/README.md
@@ -80,8 +80,10 @@ Optional `NEXT_PUBLIC_*` variables documented in `.env.example` are read by
   source of truth for copy, navigation, SEO strings, and per-page body grids.
   Routes live under `src/app/[locale]/...` with root redirects (e.g. `/` →
   `/en/`).
-- **Page template:** `PageLayout` = shared header (`Navbar`) + `main` +
-  shared footer (`Footer`). Page-specific content is rendered by `PageBodyGrid`.
+- **Page template:** `[locale]/layout.tsx` wraps every locale route with
+  `PageLayout` (shared `Navbar` header + `main` + `Footer`). Page routes
+  render `PageBodyGrid` via `MarketingPage`. Mobile nav uses a drawer;
+  WhatsApp FAB shows on small screens, footer link on `sm+`.
 - **12-column body grid:** Each page defines `pages.<key>.body.rows[]` with
   cells (`component`, `colStart`, `colSpan`, optional `props`). Register new
   body components in `page-body-grid.tsx`.

--- a/apps/public_www/next.config.ts
+++ b/apps/public_www/next.config.ts
@@ -1,10 +1,17 @@
 import type { NextConfig } from 'next';
 
+const buildYear = String(
+  process.env.NEXT_PUBLIC_BUILD_YEAR ?? new Date().getFullYear(),
+);
+
 const nextConfig: NextConfig = {
   output: 'export',
   trailingSlash: true,
   reactStrictMode: true,
   poweredByHeader: false,
+  env: {
+    NEXT_PUBLIC_BUILD_YEAR: buildYear,
+  },
   images: {
     unoptimized: true,
   },

--- a/apps/public_www/src/app/[locale]/about/page.tsx
+++ b/apps/public_www/src/app/[locale]/about/page.tsx
@@ -37,7 +37,6 @@ export default async function AboutRoutePage({ params }: LocaleRouteProps) {
       locale={locale}
       content={content}
       body={content.pages.about.body}
-      currentPath={ROUTES.about}
     />
   );
 }

--- a/apps/public_www/src/app/[locale]/error.tsx
+++ b/apps/public_www/src/app/[locale]/error.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { LocaleErrorPage } from '@/components/shared/locale-error-page';
+
+interface LocaleErrorBoundaryProps {
+  readonly reset: () => void;
+}
+
+export default function LocaleErrorBoundary({ reset }: LocaleErrorBoundaryProps) {
+  return <LocaleErrorPage reset={reset} />;
+}

--- a/apps/public_www/src/app/[locale]/layout.tsx
+++ b/apps/public_www/src/app/[locale]/layout.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from 'react';
 
+import { PageLayout } from '@/components/shared/page-layout';
+import { WhatsappFab } from '@/components/shared/whatsapp-fab';
 import {
   generateLocaleStaticParams,
   type LocaleRouteParams,
@@ -51,16 +53,15 @@ export default async function LocaleLayout({
           </p>
         </section>
       </noscript>
-      {children}
+      <PageLayout
+        locale={locale}
+        navbarContent={content.navbar}
+        footerContent={content.footer}
+      >
+        {children}
+      </PageLayout>
       {publicSiteConfig.whatsappUrl ? (
-        <a
-          href={publicSiteConfig.whatsappUrl}
-          className="fixed bottom-6 right-6 z-40 rounded-full bg-brand-500 px-4 py-3 text-sm font-semibold text-white shadow-lg transition hover:bg-brand-600"
-          target="_blank"
-          rel="noreferrer noopener"
-        >
-          WhatsApp
-        </a>
+        <WhatsappFab label={content.common.shell.whatsappFabLabel} />
       ) : null}
     </div>
   );

--- a/apps/public_www/src/app/[locale]/not-found.tsx
+++ b/apps/public_www/src/app/[locale]/not-found.tsx
@@ -1,0 +1,5 @@
+import { LocaleNotFoundPage } from '@/components/shared/locale-not-found-page';
+
+export default function LocaleSegmentNotFoundPage() {
+  return <LocaleNotFoundPage />;
+}

--- a/apps/public_www/src/app/[locale]/page.tsx
+++ b/apps/public_www/src/app/[locale]/page.tsx
@@ -37,7 +37,6 @@ export default async function HomeRoutePage({ params }: LocaleRouteProps) {
       locale={locale}
       content={content}
       body={content.pages.home.body}
-      currentPath={ROUTES.home}
     />
   );
 }

--- a/apps/public_www/src/app/error.tsx
+++ b/apps/public_www/src/app/error.tsx
@@ -1,31 +1,11 @@
 'use client';
 
-interface ErrorPageProps {
-  readonly error: Error & { digest?: string };
+import { LocaleChromeStatusPage } from '@/components/shared/locale-chrome-status-page';
+
+interface RootErrorPageProps {
   readonly reset: () => void;
 }
 
-export default function ErrorPage({ reset }: ErrorPageProps) {
-  return (
-    <main className="flex min-h-screen items-center justify-center bg-brand-50 px-6">
-      <div className="max-w-md text-center">
-        <p className="text-sm font-semibold uppercase tracking-widest text-brand-500">
-          500
-        </p>
-        <h1 className="mt-4 text-3xl font-bold tracking-tight text-ink-900">
-          Something went wrong
-        </h1>
-        <p className="mt-3 text-base text-ink-700">
-          Please try again in a moment.
-        </p>
-        <button
-          type="button"
-          onClick={reset}
-          className="mt-8 inline-block rounded-full bg-brand-500 px-5 py-2 font-semibold text-white transition hover:bg-brand-600"
-        >
-          Retry
-        </button>
-      </div>
-    </main>
-  );
+export default function RootErrorPage({ reset }: RootErrorPageProps) {
+  return <LocaleChromeStatusPage variant="serverError" onRetry={reset} />;
 }

--- a/apps/public_www/src/app/not-found.tsx
+++ b/apps/public_www/src/app/not-found.tsx
@@ -1,25 +1,5 @@
-import Link from 'next/link';
+import { LocaleChromeStatusPage } from '@/components/shared/locale-chrome-status-page';
 
 export default function NotFound() {
-  return (
-    <main className="flex min-h-screen items-center justify-center bg-brand-50 px-6">
-      <div className="max-w-md text-center">
-        <p className="text-sm font-semibold uppercase tracking-widest text-brand-500">
-          404
-        </p>
-        <h1 className="mt-4 text-3xl font-bold tracking-tight text-ink-900">
-          Page not found
-        </h1>
-        <p className="mt-3 text-base text-ink-700">
-          The page you were looking for doesn&apos;t exist or has moved.
-        </p>
-        <Link
-          href="/"
-          className="mt-8 inline-block rounded-full bg-brand-500 px-5 py-2 font-semibold text-white transition hover:bg-brand-600"
-        >
-          Back to home
-        </Link>
-      </div>
-    </main>
-  );
+  return <LocaleChromeStatusPage variant="notFound" />;
 }

--- a/apps/public_www/src/components/pages/marketing-page.tsx
+++ b/apps/public_www/src/components/pages/marketing-page.tsx
@@ -1,28 +1,12 @@
 import type { Locale, PageBodyGridConfig, SiteContent } from '@/content';
 import { PageBodyGrid } from '@/components/sections/grid/page-body-grid';
-import { PageLayout } from '@/components/shared/page-layout';
 
 interface MarketingPageProps {
   readonly locale: Locale;
   readonly content: SiteContent;
   readonly body: PageBodyGridConfig;
-  readonly currentPath: string;
 }
 
-export function MarketingPage({
-  locale,
-  content,
-  body,
-  currentPath,
-}: MarketingPageProps) {
-  return (
-    <PageLayout
-      locale={locale}
-      navbarContent={content.navbar}
-      footerContent={content.footer}
-      currentPath={currentPath}
-    >
-      <PageBodyGrid locale={locale} content={content} body={body} />
-    </PageLayout>
-  );
+export function MarketingPage({ locale, content, body }: MarketingPageProps) {
+  return <PageBodyGrid locale={locale} content={content} body={body} />;
 }

--- a/apps/public_www/src/components/sections/footer.tsx
+++ b/apps/public_www/src/components/sections/footer.tsx
@@ -1,6 +1,6 @@
 import type { FooterContent } from '@/content';
 import { formatContentTemplate } from '@/content/content-field-utils';
-import { getSiteConfig } from '@/lib/site-config';
+import { getCopyrightYear, getSiteConfig } from '@/lib/site-config';
 
 interface FooterProps {
   readonly content: FooterContent;
@@ -8,7 +8,7 @@ interface FooterProps {
 
 export function Footer({ content }: FooterProps) {
   const { siteName, contact } = getSiteConfig();
-  const year = new Date().getFullYear();
+  const year = getCopyrightYear();
   const copyright = formatContentTemplate(content.copyrightTemplate, {
     year: String(year),
   });
@@ -19,7 +19,7 @@ export function Footer({ content }: FooterProps) {
       className="bg-brand-700 text-brand-100"
       data-section-id="footer"
     >
-      <div className="mx-auto max-w-5xl px-6 py-12">
+      <div className="mx-auto max-w-5xl px-4 py-10 sm:px-6 sm:py-12">
         <div className="grid gap-8 sm:grid-cols-2">
           <div>
             <p className="text-lg font-semibold text-white">{siteName}</p>
@@ -38,7 +38,7 @@ export function Footer({ content }: FooterProps) {
               </p>
             ) : null}
             {contact.whatsappUrl ? (
-              <p className="mt-1">
+              <p className="mt-1 hidden sm:block">
                 <a
                   href={contact.whatsappUrl}
                   target="_blank"

--- a/apps/public_www/src/components/sections/navbar-language-switcher.tsx
+++ b/apps/public_www/src/components/sections/navbar-language-switcher.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+import { isValidLocale, type Locale, type NavbarContent } from '@/content';
+import { localizeHref, normalizeLocalizedPath } from '@/lib/locale-routing';
+
+interface NavbarLanguageSwitcherProps {
+  readonly locale: Locale;
+  readonly content: NavbarContent;
+}
+
+export function NavbarLanguageSwitcher({
+  locale,
+  content,
+}: NavbarLanguageSwitcherProps) {
+  const pathname = usePathname();
+  const currentPath = normalizeLocalizedPath(pathname ?? '/');
+
+  return (
+    <div
+      className="flex items-center gap-1"
+      role="navigation"
+      aria-label={content.languageSelector.menuAriaLabel}
+    >
+      {content.languageSelector.options.map((option) => {
+        if (!isValidLocale(option.locale)) {
+          return null;
+        }
+
+        return (
+          <Link
+            key={option.locale}
+            href={localizeHref(currentPath, option.locale)}
+            className={`inline-flex min-h-11 min-w-11 items-center justify-center rounded-md px-2 text-xs font-semibold uppercase tracking-wide ${
+              option.locale === locale
+                ? 'bg-brand-500 text-white'
+                : 'text-ink-700 hover:bg-brand-50'
+            }`}
+            aria-current={option.locale === locale ? 'page' : undefined}
+          >
+            {option.shortLabel}
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/public_www/src/components/sections/navbar-mobile-menu.tsx
+++ b/apps/public_www/src/components/sections/navbar-mobile-menu.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useCallback, useEffect, useId, useState } from 'react';
+
+import type { Locale, NavbarContent } from '@/content';
+import { localizeHref } from '@/lib/locale-routing';
+
+interface NavbarMobileMenuProps {
+  readonly locale: Locale;
+  readonly content: NavbarContent;
+}
+
+export function NavbarMobileMenu({ locale, content }: NavbarMobileMenuProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const panelId = useId();
+  const pathname = usePathname();
+
+  const closeMenu = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [isOpen]);
+
+  return (
+    <div key={pathname} className="md:hidden">
+      <button
+        type="button"
+        className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-md border border-brand-200 px-3 text-sm font-semibold text-brand-700"
+        aria-expanded={isOpen}
+        aria-controls={panelId}
+        onClick={() => {
+          setIsOpen((open) => !open);
+        }}
+      >
+        <span className="sr-only">
+          {isOpen
+            ? content.closeNavigationMenuAriaLabel
+            : content.openNavigationMenuAriaLabel}
+        </span>
+        <span aria-hidden="true">{isOpen ? '×' : '☰'}</span>
+      </button>
+      {isOpen ? (
+        <div
+          id={panelId}
+          className="absolute inset-x-0 top-full z-50 border-b border-brand-100 bg-white shadow-lg"
+        >
+          <nav
+            className="mx-auto flex max-w-7xl flex-col gap-1 px-4 py-3 sm:px-6"
+            aria-label="Main"
+          >
+            {content.menuItems.map((item) => (
+              <Link
+                key={item.href}
+                href={localizeHref(item.href, locale)}
+                className="min-h-11 rounded-md px-3 py-3 text-base font-medium text-ink-700 transition hover:bg-brand-50 hover:text-brand-600"
+                onClick={closeMenu}
+              >
+                {item.label}
+              </Link>
+            ))}
+          </nav>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/public_www/src/components/sections/navbar.tsx
+++ b/apps/public_www/src/components/sections/navbar.tsx
@@ -1,69 +1,50 @@
 import Link from 'next/link';
 
-import {
-  isValidLocale,
-  type Locale,
-  type NavbarContent,
-} from '@/content';
+import type { Locale, NavbarContent } from '@/content';
 import { localizeHref } from '@/lib/locale-routing';
 import { ROUTES } from '@/lib/routes';
+
+import { NavbarLanguageSwitcher } from './navbar-language-switcher';
+import { NavbarMobileMenu } from './navbar-mobile-menu';
 
 interface NavbarProps {
   readonly locale: Locale;
   readonly content: NavbarContent;
-  readonly currentPath?: string;
 }
 
-export function Navbar({ locale, content, currentPath = ROUTES.home }: NavbarProps) {
+export function Navbar({ locale, content }: NavbarProps) {
   return (
-    <header className="border-b border-brand-100 bg-white">
-      <div className="mx-auto flex max-w-7xl items-center justify-between gap-6 px-4 py-4 sm:px-6 lg:px-8">
-        <Link
-          href={localizeHref(ROUTES.home, locale)}
-          className="text-lg font-bold text-brand-700"
-        >
-          {content.brand}
-        </Link>
+    <header className="relative border-b border-brand-100 bg-white">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="flex min-h-14 items-center justify-between gap-3 py-3 sm:min-h-16">
+          <Link
+            href={localizeHref(ROUTES.home, locale)}
+            className="text-base font-bold text-brand-700 sm:text-lg"
+          >
+            {content.brand}
+          </Link>
+          <div className="flex items-center gap-2">
+            <NavbarLanguageSwitcher locale={locale} content={content} />
+            <NavbarMobileMenu locale={locale} content={content} />
+          </div>
+        </div>
         <nav
-          className="hidden items-center gap-6 text-sm font-medium text-ink-700 md:flex"
+          className="hidden border-t border-brand-50 pb-3 pt-2 md:block"
           aria-label="Main"
         >
-          {content.menuItems.map((item) => (
-            <Link
-              key={item.href}
-              href={localizeHref(item.href, locale)}
-              className="transition hover:text-brand-600"
-            >
-              {item.label}
-            </Link>
-          ))}
+          <ul className="flex flex-wrap items-center gap-1">
+            {content.menuItems.map((item) => (
+              <li key={item.href}>
+                <Link
+                  href={localizeHref(item.href, locale)}
+                  className="inline-flex min-h-11 items-center rounded-md px-3 text-sm font-medium text-ink-700 transition hover:bg-brand-50 hover:text-brand-600"
+                >
+                  {item.label}
+                </Link>
+              </li>
+            ))}
+          </ul>
         </nav>
-        <div
-          className="flex items-center gap-2"
-          role="navigation"
-          aria-label={content.languageSelector.menuAriaLabel}
-        >
-          {content.languageSelector.options.map((option) => {
-            if (!isValidLocale(option.locale)) {
-              return null;
-            }
-
-            return (
-            <Link
-              key={option.locale}
-              href={localizeHref(currentPath, option.locale)}
-              className={`rounded-md px-2 py-1 text-xs font-semibold uppercase tracking-wide ${
-                option.locale === locale
-                  ? 'bg-brand-500 text-white'
-                  : 'text-ink-700 hover:bg-brand-50'
-              }`}
-              aria-current={option.locale === locale ? 'page' : undefined}
-            >
-              {option.shortLabel}
-            </Link>
-            );
-          })}
-        </div>
       </div>
     </header>
   );

--- a/apps/public_www/src/components/shared/locale-chrome-status-page.tsx
+++ b/apps/public_www/src/components/shared/locale-chrome-status-page.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+
+import { PageLayout } from '@/components/shared/page-layout';
+import { StatusPage } from '@/components/shared/status-page';
+import { getContent } from '@/content';
+import { getLocaleFromPath } from '@/lib/locale-routing';
+
+interface LocaleChromeStatusPageProps {
+  readonly variant: 'notFound' | 'serverError';
+  readonly onRetry?: () => void;
+}
+
+export function LocaleChromeStatusPage({
+  variant,
+  onRetry,
+}: LocaleChromeStatusPageProps) {
+  const pathname = usePathname();
+  const locale = getLocaleFromPath(pathname ?? '/');
+  const content = getContent(locale);
+  const copy =
+    variant === 'notFound'
+      ? content.common.errors.notFound
+      : content.common.errors.serverError;
+
+  return (
+    <PageLayout
+      locale={locale}
+      navbarContent={content.navbar}
+      footerContent={content.footer}
+    >
+      <StatusPage
+        locale={locale}
+        copy={copy}
+        homeLabel={content.common.errors.notFound.homeLabel}
+        action={
+          variant === 'serverError' && onRetry
+            ? {
+                label: content.common.errors.serverError.retryLabel,
+                onClick: onRetry,
+              }
+            : undefined
+        }
+      />
+    </PageLayout>
+  );
+}

--- a/apps/public_www/src/components/shared/locale-error-page.tsx
+++ b/apps/public_www/src/components/shared/locale-error-page.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+
+import { StatusPage } from '@/components/shared/status-page';
+import { getContent } from '@/content';
+import { getLocaleFromPath } from '@/lib/locale-routing';
+
+interface LocaleErrorPageProps {
+  readonly reset: () => void;
+}
+
+export function LocaleErrorPage({ reset }: LocaleErrorPageProps) {
+  const pathname = usePathname();
+  const locale = getLocaleFromPath(pathname ?? '/');
+  const content = getContent(locale);
+  const copy = content.common.errors.serverError;
+
+  return (
+    <StatusPage
+      locale={locale}
+      copy={copy}
+      homeLabel={content.common.errors.notFound.homeLabel}
+      action={{
+        label: copy.retryLabel,
+        onClick: reset,
+      }}
+    />
+  );
+}

--- a/apps/public_www/src/components/shared/locale-not-found-page.tsx
+++ b/apps/public_www/src/components/shared/locale-not-found-page.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+
+import { StatusPage } from '@/components/shared/status-page';
+import { getContent } from '@/content';
+import { getLocaleFromPath } from '@/lib/locale-routing';
+
+export function LocaleNotFoundPage() {
+  const pathname = usePathname();
+  const locale = getLocaleFromPath(pathname ?? '/');
+  const content = getContent(locale);
+  const copy = content.common.errors.notFound;
+
+  return (
+    <StatusPage locale={locale} copy={copy} homeLabel={copy.homeLabel} />
+  );
+}

--- a/apps/public_www/src/components/shared/page-layout.tsx
+++ b/apps/public_www/src/components/shared/page-layout.tsx
@@ -8,7 +8,6 @@ interface PageLayoutProps {
   readonly locale: Locale;
   readonly navbarContent: NavbarContent;
   readonly footerContent: FooterContent;
-  readonly currentPath?: string;
   readonly children: ReactNode;
   readonly mainClassName?: string;
   readonly mainId?: string;
@@ -20,18 +19,13 @@ export function PageLayout({
   locale,
   navbarContent,
   footerContent,
-  currentPath,
   children,
   mainClassName,
   mainId = 'main-content',
 }: PageLayoutProps) {
   return (
     <div className="flex min-h-screen flex-col">
-      <Navbar
-        locale={locale}
-        content={navbarContent}
-        currentPath={currentPath}
-      />
+      <Navbar locale={locale} content={navbarContent} />
       <main
         id={mainId}
         tabIndex={-1}

--- a/apps/public_www/src/components/shared/status-page.tsx
+++ b/apps/public_www/src/components/shared/status-page.tsx
@@ -1,0 +1,59 @@
+import Link from 'next/link';
+
+import type { Locale } from '@/content';
+import { localizePath } from '@/lib/locale-routing';
+import { ROUTES } from '@/lib/routes';
+
+interface StatusPageCopy {
+  readonly code: string;
+  readonly title: string;
+  readonly description: string;
+}
+
+interface StatusPageProps {
+  readonly locale: Locale;
+  readonly copy: StatusPageCopy;
+  readonly homeLabel: string;
+  readonly action?: {
+    readonly label: string;
+    readonly onClick: () => void;
+  };
+}
+
+export function StatusPage({
+  locale,
+  copy,
+  homeLabel,
+  action,
+}: StatusPageProps) {
+  const homeHref = localizePath(ROUTES.home, locale);
+
+  return (
+    <div className="mx-auto flex max-w-md flex-col items-center px-4 py-16 text-center sm:py-24">
+      <p className="text-sm font-semibold uppercase tracking-widest text-brand-500">
+        {copy.code}
+      </p>
+      <h1 className="mt-4 text-2xl font-bold tracking-tight text-ink-900 sm:text-3xl">
+        {copy.title}
+      </h1>
+      <p className="mt-3 text-base text-ink-700">{copy.description}</p>
+      <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+        <Link
+          href={homeHref}
+          className="inline-flex min-h-11 items-center justify-center rounded-full bg-brand-500 px-5 py-2 font-semibold text-white transition hover:bg-brand-600"
+        >
+          {homeLabel}
+        </Link>
+        {action ? (
+          <button
+            type="button"
+            onClick={action.onClick}
+            className="inline-flex min-h-11 items-center justify-center rounded-full border border-brand-300 bg-white px-5 py-2 font-semibold text-brand-700 transition hover:bg-brand-50"
+          >
+            {action.label}
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/public_www/src/components/shared/whatsapp-fab.tsx
+++ b/apps/public_www/src/components/shared/whatsapp-fab.tsx
@@ -1,0 +1,24 @@
+import { getSiteConfig } from '@/lib/site-config';
+
+interface WhatsappFabProps {
+  readonly label: string;
+}
+
+export function WhatsappFab({ label }: WhatsappFabProps) {
+  const { contact } = getSiteConfig();
+
+  if (!contact.whatsappUrl) {
+    return null;
+  }
+
+  return (
+    <a
+      href={contact.whatsappUrl}
+      className="fixed bottom-4 right-4 z-40 inline-flex min-h-12 items-center rounded-full bg-brand-500 px-4 py-3 text-sm font-semibold text-white shadow-lg transition hover:bg-brand-600 sm:hidden"
+      target="_blank"
+      rel="noreferrer noopener"
+    >
+      {label}
+    </a>
+  );
+}

--- a/apps/public_www/src/content/en.json
+++ b/apps/public_www/src/content/en.json
@@ -43,11 +43,26 @@
     "shell": {
       "skipToMainContentLabel": "Skip to main content",
       "environmentBadgeLabel": "Staging",
+      "whatsappFabLabel": "Chat on WhatsApp",
       "noscript": {
         "title": "JavaScript is disabled",
         "description": "Core navigation still works. Enable JavaScript for the full experience.",
         "homeLabel": "Home",
         "contactLabel": "Contact"
+      }
+    },
+    "errors": {
+      "notFound": {
+        "code": "404",
+        "title": "Page not found",
+        "description": "The page you were looking for doesn't exist or has moved.",
+        "homeLabel": "Back to home"
+      },
+      "serverError": {
+        "code": "500",
+        "title": "Something went wrong",
+        "description": "Please try again in a moment.",
+        "retryLabel": "Try again"
       }
     }
   },

--- a/apps/public_www/src/content/zh-HK.json
+++ b/apps/public_www/src/content/zh-HK.json
@@ -43,11 +43,26 @@
     "shell": {
       "skipToMainContentLabel": "跳至主要內容",
       "environmentBadgeLabel": "測試環境",
+      "whatsappFabLabel": "WhatsApp 聯絡",
       "noscript": {
         "title": "已停用 JavaScript",
         "description": "基本導覽仍可使用。啟用 JavaScript 以獲得完整體驗。",
         "homeLabel": "主頁",
         "contactLabel": "聯絡"
+      }
+    },
+    "errors": {
+      "notFound": {
+        "code": "404",
+        "title": "找不到頁面",
+        "description": "您要查看的頁面不存在或已移動。",
+        "homeLabel": "返回主頁"
+      },
+      "serverError": {
+        "code": "500",
+        "title": "發生錯誤",
+        "description": "請稍後再試。",
+        "retryLabel": "重試"
       }
     }
   },

--- a/apps/public_www/src/lib/site-config.ts
+++ b/apps/public_www/src/lib/site-config.ts
@@ -41,6 +41,16 @@ export function getSiteConfig(): SiteConfig {
   };
 }
 
+export function getCopyrightYear(): number {
+  const raw = readPublicEnv('NEXT_PUBLIC_BUILD_YEAR');
+  const parsed = Number.parseInt(raw, 10);
+  if (Number.isFinite(parsed) && parsed >= 2000 && parsed <= 2100) {
+    return parsed;
+  }
+
+  return new Date().getFullYear();
+}
+
 export function resolvePublicSiteConfig(): PublicSiteConfig {
   const whatsappUrl = readPublicEnv('NEXT_PUBLIC_WHATSAPP_URL');
   const contactEmail = readPublicEnv('NEXT_PUBLIC_EMAIL');

--- a/apps/public_www/tests/app/page.test.tsx
+++ b/apps/public_www/tests/app/page.test.tsx
@@ -1,20 +1,30 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { MarketingPage } from '@/components/pages/marketing-page';
+import { PageLayout } from '@/components/shared/page-layout';
 import { getContent } from '@/content';
 
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/en/',
+}));
+
 describe('MarketingPage', () => {
-  it('renders home grid sections from locale content', () => {
+  it('renders home grid sections inside locale chrome', () => {
     const content = getContent('en');
 
     render(
-      <MarketingPage
+      <PageLayout
         locale="en"
-        content={content}
-        body={content.pages.home.body}
-        currentPath="/"
-      />,
+        navbarContent={content.navbar}
+        footerContent={content.footer}
+      >
+        <MarketingPage
+          locale="en"
+          content={content}
+          body={content.pages.home.body}
+        />
+      </PageLayout>,
     );
 
     expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
@@ -24,5 +34,8 @@ describe('MarketingPage', () => {
       content.features.title,
     );
     expect(screen.getByRole('navigation', { name: 'Main' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: content.navbar.openNavigationMenuAriaLabel }),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/public_www/tests/lib/site-config.test.ts
+++ b/apps/public_www/tests/lib/site-config.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { getCopyrightYear } from '@/lib/site-config';
+
+describe('getCopyrightYear', () => {
+  const originalYear = process.env.NEXT_PUBLIC_BUILD_YEAR;
+
+  afterEach(() => {
+    if (originalYear === undefined) {
+      delete process.env.NEXT_PUBLIC_BUILD_YEAR;
+    } else {
+      process.env.NEXT_PUBLIC_BUILD_YEAR = originalYear;
+    }
+  });
+
+  it('uses NEXT_PUBLIC_BUILD_YEAR when valid', () => {
+    process.env.NEXT_PUBLIC_BUILD_YEAR = '2030';
+    expect(getCopyrightYear()).toBe(2030);
+  });
+
+  it('falls back when env is missing or invalid', () => {
+    delete process.env.NEXT_PUBLIC_BUILD_YEAR;
+    expect(getCopyrightYear()).toBe(new Date().getFullYear());
+  });
+});

--- a/docs/architecture/public-www.md
+++ b/docs/architecture/public-www.md
@@ -72,7 +72,9 @@ Source: [`apps/public_www`](../../apps/public_www).
 
 - **Locales:** `src/content/en.json`, `zh-HK.json`, … with routes under
   `src/app/[locale]/…` and root redirects (`/` → `/en/`).
-- **Template:** `PageLayout` = `Navbar` (header) + `<main>` + `Footer`.
+- **Template:** `[locale]/layout.tsx` wraps routes with `PageLayout`
+  (`Navbar` header + `<main>` + `Footer`). Mobile drawer nav; WhatsApp FAB
+  on small screens, footer link on larger breakpoints.
 - **Body:** `pages.<pageKey>.body` defines a 12-column CSS grid (`rows` →
   `cells` with `component`, `colStart`, `colSpan`, optional `props`). The
   registry lives in `src/components/sections/grid/page-body-grid.tsx`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes the public marketing site mobile-first and applies the layout/UX improvements discussed for header/footer consistency.

## Changes

- **Mobile navigation:** Hamburger drawer on small screens (`NavbarMobileMenu`) with 44px touch targets; desktop horizontal nav from `md` up.
- **Language switcher:** Uses `usePathname()` so locale switches preserve the current route without per-page `currentPath` props.
- **Layout hoist:** `[locale]/layout.tsx` wraps all locale routes with `PageLayout` (header + main + footer). `MarketingPage` now only renders `PageBodyGrid`.
- **Error pages:** Localized 404/500 copy in `en.json` / `zh-HK.json`. Locale routes use chrome via layout; root `not-found` / `error` use `LocaleChromeStatusPage`.
- **WhatsApp:** Fixed FAB on screens below `sm`; footer WhatsApp link hidden on mobile to avoid duplication.
- **Copyright year:** `NEXT_PUBLIC_BUILD_YEAR` set at build time via `next.config.ts` (`getCopyrightYear()`).

## Testing

- `npm run typecheck` — pass
- `npm run test` — 8 tests pass
- `NEXT_PUBLIC_SITE_ORIGIN=... NEXT_PUBLIC_SITE_NAME=... npm run build` — pass
- `npm run lint` — pre-existing warning in `eslint.config.mjs` only (not introduced here)

## Docs

- Updated `apps/public_www/README.md` and `docs/architecture/public-www.md` for the new layout pattern.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3deb9689-00a7-4801-8b91-92b833876887"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3deb9689-00a7-4801-8b91-92b833876887"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

