### PR TITLE
fix(public_www): restore page body grid column placement

### DIFF
--- a/apps/public_www/src/app/globals.css
+++ b/apps/public_www/src/app/globals.css
@@ -33,3 +33,84 @@ button:focus-visible {
   outline-offset: 2px;
   border-radius: 4px;
 }
+
+/* Page grid cells use data attributes so placement works in static export
+   (Tailwind cannot emit dynamically built col-[n_/span_m] utilities). */
+.page-body-grid__cell {
+  grid-column-start: var(--page-grid-col-start, 1);
+  grid-column-end: span var(--page-grid-col-span, 1);
+}
+
+.page-body-grid__cell[data-grid-col-start='1'] {
+  --page-grid-col-start: 1;
+}
+.page-body-grid__cell[data-grid-col-start='2'] {
+  --page-grid-col-start: 2;
+}
+.page-body-grid__cell[data-grid-col-start='3'] {
+  --page-grid-col-start: 3;
+}
+.page-body-grid__cell[data-grid-col-start='4'] {
+  --page-grid-col-start: 4;
+}
+.page-body-grid__cell[data-grid-col-start='5'] {
+  --page-grid-col-start: 5;
+}
+.page-body-grid__cell[data-grid-col-start='6'] {
+  --page-grid-col-start: 6;
+}
+.page-body-grid__cell[data-grid-col-start='7'] {
+  --page-grid-col-start: 7;
+}
+.page-body-grid__cell[data-grid-col-start='8'] {
+  --page-grid-col-start: 8;
+}
+.page-body-grid__cell[data-grid-col-start='9'] {
+  --page-grid-col-start: 9;
+}
+.page-body-grid__cell[data-grid-col-start='10'] {
+  --page-grid-col-start: 10;
+}
+.page-body-grid__cell[data-grid-col-start='11'] {
+  --page-grid-col-start: 11;
+}
+.page-body-grid__cell[data-grid-col-start='12'] {
+  --page-grid-col-start: 12;
+}
+
+.page-body-grid__cell[data-grid-col-span='1'] {
+  --page-grid-col-span: 1;
+}
+.page-body-grid__cell[data-grid-col-span='2'] {
+  --page-grid-col-span: 2;
+}
+.page-body-grid__cell[data-grid-col-span='3'] {
+  --page-grid-col-span: 3;
+}
+.page-body-grid__cell[data-grid-col-span='4'] {
+  --page-grid-col-span: 4;
+}
+.page-body-grid__cell[data-grid-col-span='5'] {
+  --page-grid-col-span: 5;
+}
+.page-body-grid__cell[data-grid-col-span='6'] {
+  --page-grid-col-span: 6;
+}
+.page-body-grid__cell[data-grid-col-span='7'] {
+  --page-grid-col-span: 7;
+}
+.page-body-grid__cell[data-grid-col-span='8'] {
+  --page-grid-col-span: 8;
+}
+.page-body-grid__cell[data-grid-col-span='9'] {
+  --page-grid-col-span: 9;
+}
+.page-body-grid__cell[data-grid-col-span='10'] {
+  --page-grid-col-span: 10;
+}
+.page-body-grid__cell[data-grid-col-span='11'] {
+  --page-grid-col-span: 11;
+}
+.page-body-grid__cell[data-grid-col-span='12'] {
+  --page-grid-col-span: 12;
+}

--- a/apps/public_www/src/components/sections/grid/page-body-grid.tsx
+++ b/apps/public_www/src/components/sections/grid/page-body-grid.tsx
@@ -92,12 +92,11 @@ export function PageBodyGrid({ locale, content, body }: PageBodyGridProps) {
           {row.cells.map((cell, cellIndex) => {
             const colStart = cell.colStart ?? 1;
             const colSpan = cell.colSpan;
-            const columnClass = `col-[${colStart}_/span_${colSpan}]`;
 
             return (
               <div
                 key={`page-grid-cell-${rowIndex}-${cellIndex}`}
-                className={`page-body-grid__cell min-w-0 ${columnClass}`}
+                className="page-body-grid__cell min-w-0"
                 data-grid-col-start={colStart}
                 data-grid-col-span={colSpan}
                 data-component={cell.component}

--- a/apps/public_www/tests/app/page.test.tsx
+++ b/apps/public_www/tests/app/page.test.tsx
@@ -37,5 +37,13 @@ describe('MarketingPage', () => {
     expect(
       screen.getByRole('button', { name: content.navbar.openNavigationMenuAriaLabel }),
     ).toBeInTheDocument();
+
+    const gridCells = document.querySelectorAll('.page-body-grid__cell');
+    expect(gridCells.length).toBeGreaterThan(0);
+    for (const cell of gridCells) {
+      expect(cell.className).not.toMatch(/col-\[/);
+      expect(cell).toHaveAttribute('data-grid-col-span');
+      expect(cell).toHaveAttribute('data-grid-col-start');
+    }
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The public website page body grid used dynamically constructed Tailwind classes (`col-[${colStart}_/span_${colSpan}]`). Tailwind's compiler only emits utilities it can see as complete strings at build time, so those classes were missing from the static export CSS. Grid cells defaulted to a single column in the 12-column layout, which squashed hero, features, and rich-text sections.

## Solution

- Drive grid placement from existing `data-grid-col-start` / `data-grid-col-span` attributes via CSS custom properties in `globals.css`.
- Remove the ineffective dynamic Tailwind class from `page-body-grid.tsx`.
- Add a regression test ensuring grid cells keep data attributes and do not rely on dynamic `col-[…]` utilities.

## Testing

- `cd apps/public_www && npm test`
- `npm run build` with required `NEXT_PUBLIC_*` env vars; verified built CSS includes `page-grid-col` rules and HTML no longer references `col-[…]` classes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-edaa49ce-fad1-49a8-98d2-ee31694aab98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-edaa49ce-fad1-49a8-98d2-ee31694aab98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

