### PR TITLE
fix(ci): ensure Semgrep SARIF file exists before upload-sarif

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -190,11 +190,16 @@ jobs:
         #   URLs before use (HTTPS only, .amazonaws.com hosts only). The validation
         #   prevents the file:// scheme attack vector. See backend/src/app/utils/cfn_response.py
         run: |
-          semgrep ci \
+          semgrep scan \
             --sarif \
-            --output=semgrep-results.sarif \
+            --sarif-output=semgrep-results.sarif \
             --exclude-rule python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected \
             || true
+          if [ ! -f semgrep-results.sarif ]; then
+            printf '%s\n' \
+              '{"version":"2.1.0","$schema":"https://json.schemastore.org/sarif-2.1.0.json","runs":[]}' \
+              > semgrep-results.sarif
+          fi
         env:
           SEMGREP_RULES: >-
             p/python
@@ -207,6 +212,7 @@ jobs:
         if: always()
         with:
           sarif_file: semgrep-results.sarif
+          category: semgrep
 
   # Summary job
   security-summary:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The `semgrep` job failed at `github/codeql-action/upload-sarif@v4` with:

```
Error: Path does not exist: semgrep-results.sarif
```

The workflow ran `semgrep ci --sarif --output=semgrep-results.sarif`. Semgrep expects SARIF at `--sarif-output`, not `--output`, so no file was written before upload.

## Solution

- Switch to `semgrep scan` (OSS CI path using `SEMGREP_RULES`).
- Write SARIF with `--sarif-output=semgrep-results.sarif`.
- If the scan exits without creating the file, write a minimal empty SARIF document so `upload-sarif` always has a valid path.
- Set `category: semgrep` on the SARIF upload for clarity when multiple tools upload in the same workflow.

## Testing

- Workflow change only; validated command flags against Semgrep CLI docs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-edaa49ce-fad1-49a8-98d2-ee31694aab98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-edaa49ce-fad1-49a8-98d2-ee31694aab98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

