### PR TITLE
Home wizard: sequential search with HK macro regions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,25 +8,70 @@
 |---------|-----------|---------|---------|
 | Python backend | `backend/` | Python 3.12 | Lambda handlers, DB migrations, tests |
 | Admin web | `apps/admin_web/` | Node.js 24 (npm) | Next.js admin SPA |
+| Public website | `apps/public_www/` | Node.js 24 (npm) | Next.js static marketing site |
 | CDK infrastructure | `backend/infrastructure/` | Node.js 24 (npm) | AWS CDK IaC |
 | Flutter app | `apps/siutindei_app/` | Flutter stable | Mobile app (not set up in cloud) |
 
 ### Running services
 
 - **Admin web dev server**: `cd apps/admin_web && npm run dev` (port 3000)
+- **Public www dev server**: `cd apps/public_www && npm run dev` (port 3000)
 - **PostgreSQL**: `service postgresql start` then connect at `postgresql+psycopg://postgres:postgres@localhost:5432/backend_test`
 
-### Lint / Test / Build commands
+### Lint / test / build (run before commit)
 
-See `package.json` scripts and `.github/workflows/lint.yml` / `test.yml` for canonical commands. Key shortcuts:
+Source Node from nvm first:
 
-- **Python lint**: `ruff check backend/` and `ruff format --check backend/`
-- **Python tests**: `PYTHONPATH=backend/src DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5432/backend_test python3 -m pytest tests backend`
-- **Admin web lint**: `cd apps/admin_web && npm run lint`
-- **Admin web typecheck**: `cd apps/admin_web && npm run typecheck`
-- **Admin web E2E**: `cd apps/admin_web && npx playwright test` (requires Chromium; dev server must be running on port 3000)
-- **CDK build**: `cd backend/infrastructure && npm run build`
-- **Pre-commit (all)**: `pre-commit run --all-files`
+```bash
+export NVM_DIR="/home/ubuntu/.nvm" && . "$NVM_DIR/nvm.sh"
+```
+
+#### All projects (matches CI `lint.yml` + `test.yml`)
+
+```bash
+# Python — format, lint, unit tests
+pre-commit run --all-files
+PYTHONPATH=backend/src DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5432/backend_test \
+  python3 -m pytest tests backend -q
+
+# Admin web
+cd apps/admin_web && npm ci && npm run lint && npm run typecheck
+cd apps/admin_web && npm run generate:api  # then verify generated types are committed
+
+# Public website
+cd apps/public_www && npm ci && npm run lint && npm run typecheck && npm test
+
+# CDK infrastructure
+cd backend/infrastructure && npm ci && npm run lint && npm run build
+
+# Flutter (when SDK is available)
+cd apps/siutindei_app && flutter pub get && flutter analyze && flutter test
+```
+
+#### Quick per-package shortcuts
+
+| Package | Lint | Typecheck | Unit tests |
+|---------|------|-----------|------------|
+| Backend | `ruff check backend/` · `ruff format --check backend/` | — | `pytest tests backend` (see above) |
+| Admin web | `npm run lint` | `npm run typecheck` | — |
+| Public www | `npm run lint` | `npm run typecheck` | `npm test` |
+| CDK | `npm run lint` | `npm run build` | — |
+| Flutter | `flutter analyze` | — | `flutter test` |
+
+Public www production build (requires env contract):
+
+```bash
+cd apps/public_www
+NEXT_PUBLIC_SITE_ORIGIN=http://localhost:3000 \
+NEXT_PUBLIC_SITE_NAME="Siu Tin Dei" \
+npm run build
+```
+
+Admin web E2E (Chromium + dev server on port 3000):
+
+```bash
+cd apps/admin_web && npx playwright test
+```
 
 ### Non-obvious caveats
 
@@ -36,4 +81,5 @@ See `package.json` scripts and `.github/workflows/lint.yml` / `test.yml` for can
 - PostgreSQL pg_hba.conf must be set to `md5` auth (not `peer`) for password-based connections. After install, run: `sed -i 's/local\s*all\s*all\s*peer/local all all md5/' /etc/postgresql/16/main/pg_hba.conf && service postgresql restart`.
 - E2E tests for login/auth-related flows require Cognito env vars. Tests that don't need real auth sessions pass; authenticated flow tests fail without a real Cognito pool. The test fixtures mock auth via `test-fixtures.ts`.
 - The admin web `.env.local` needs `NEXT_PUBLIC_API_BASE_URL`, `NEXT_PUBLIC_COGNITO_DOMAIN`, `NEXT_PUBLIC_COGNITO_CLIENT_ID`, `NEXT_PUBLIC_COGNITO_USER_POOL_ID` for full functionality. The dev server starts without them (shows config warnings).
+- Public www copies `shared/home_wizard/home_wizard_choices.json` into `apps/public_www/src/data/` for TypeScript bundling; keep both in sync when editing choices.
 - Python formatting rule: run `pre-commit run ruff-format --all-files` before any Python commit (per `.cursorrules`).

--- a/apps/admin_web/src/types/api-search.generated.ts
+++ b/apps/admin_web/src/types/api-search.generated.ts
@@ -21,8 +21,16 @@ export interface paths {
                 query?: {
                     /** @description Filter activities suitable for this age (>= 0) */
                     age?: number;
-                    /** @description Filter by geographic area UUID */
+                    /**
+                     * @description Filter by geographic area UUID. Matches activities in the given area
+                     *     or any descendant area (for example a region or district).
+                     */
                     area_id?: string;
+                    /**
+                     * @description Filter by activity category UUID. Multiple values allowed; results
+                     *     match any listed category.
+                     */
+                    category_id?: string[];
                     /**
                      * @description Filter by pricing type:
                      *     - per_class: Individual class pricing
@@ -129,9 +137,15 @@ export interface components {
             id: string;
             /**
              * Format: uuid
-             * @description Geographic area UUID (leaf node)
+             * @description Geographic area UUID (leaf district node)
              */
             area_id: string;
+            /**
+             * Format: uuid
+             * @description Macro-region ancestor UUID (for example Hong Kong Island) when the
+             *     location district belongs to a region node.
+             */
+            region_area_id?: string | null;
             address?: string | null;
             lat?: number | null;
             lng?: number | null;
@@ -145,6 +159,11 @@ export interface components {
             description_translations: components["schemas"]["TranslationMap"];
             age_min?: number | null;
             age_max?: number | null;
+            /**
+             * Format: uuid
+             * @description Activity category UUID
+             */
+            category_id?: string;
         };
         Pricing: {
             /** @enum {string} */

--- a/apps/public_www/eslint.config.mjs
+++ b/apps/public_www/eslint.config.mjs
@@ -1,6 +1,6 @@
 import nextConfig from 'eslint-config-next';
 
-export default [
+const eslintConfig = [
   ...nextConfig,
   {
     ignores: [
@@ -17,3 +17,5 @@ export default [
     },
   },
 ];
+
+export default eslintConfig;

--- a/apps/public_www/src/components/sections/grid/page-body-grid.tsx
+++ b/apps/public_www/src/components/sections/grid/page-body-grid.tsx
@@ -2,6 +2,7 @@ import type { Locale, SiteContent } from '@/content';
 import { FeaturesSection } from '@/components/sections/grid/features-section';
 import { HeroSection } from '@/components/sections/grid/hero-section';
 import { RichTextSection } from '@/components/sections/grid/rich-text-section';
+import { HomeWizardSection } from '@/components/sections/home-wizard/home-wizard-section';
 import type {
   PageBodyGridConfig,
   PageGridCellConfig,
@@ -81,6 +82,10 @@ function renderGridCell(
           secondaryCtaLabel={readStringProp(props, 'secondaryCtaLabel', '')}
           secondaryCtaHref={readStringProp(props, 'secondaryCtaHref', '#contact')}
         />
+      );
+    case 'homeWizard':
+      return (
+        <HomeWizardSection locale={locale} copy={content.homeWizard} />
       );
     case 'features':
       return <FeaturesSection content={content.features} />;

--- a/apps/public_www/src/components/sections/home-wizard/home-wizard-section.tsx
+++ b/apps/public_www/src/components/sections/home-wizard/home-wizard-section.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useId, useMemo, useState } from 'react';
 
 import type { Locale } from '@/content';
 import {
@@ -32,7 +32,14 @@ interface HomeWizardSectionProps {
   readonly copy: HomeWizardCopy;
 }
 
+const optionClassName =
+  'flex cursor-pointer items-center gap-3 rounded-lg border ' +
+  'border-slate-200 px-4 py-3 has-checked:border-brand-500 ' +
+  'has-checked:bg-brand-50 focus-within:outline focus-within:outline-2 ' +
+  'focus-within:outline-offset-2 focus-within:outline-brand-500';
+
 export function HomeWizardSection({ locale, copy }: HomeWizardSectionProps) {
+  const searchInputId = useId();
   const [step, setStep] = useState<WizardStep>('activityTypes');
   const [selectedActivityTypeIds, setSelectedActivityTypeIds] = useState<
     ReadonlySet<string>
@@ -99,13 +106,13 @@ export function HomeWizardSection({ locale, copy }: HomeWizardSectionProps) {
     [copy.errorLabel],
   );
 
-  const toggleActivityType = (activityTypeId: string) => {
+  const toggleActivityType = (activityTypeId: string, checked: boolean) => {
     setSelectedActivityTypeIds((current) => {
       const next = new Set(current);
-      if (next.has(activityTypeId)) {
-        next.delete(activityTypeId);
-      } else {
+      if (checked) {
         next.add(activityTypeId);
+      } else {
+        next.delete(activityTypeId);
       }
       return next;
     });
@@ -132,7 +139,9 @@ export function HomeWizardSection({ locale, copy }: HomeWizardSectionProps) {
   };
 
   const selectRegion = (regionId: string) => {
-    const region = homeWizardChoices.regions.find((item) => item.id === regionId);
+    const region = homeWizardChoices.regions.find(
+      (item) => item.id === regionId,
+    );
     if (!region) {
       return;
     }
@@ -186,7 +195,7 @@ export function HomeWizardSection({ locale, copy }: HomeWizardSectionProps) {
       data-section-id="home-wizard"
     >
       <div className="mx-auto max-w-3xl px-4 py-10 sm:px-6">
-        <div className="flex flex-wrap gap-2">
+        <nav aria-label="Selected filters" className="flex flex-wrap gap-2">
           {summaryChips
             .filter((chip) => chip.visible)
             .map((chip) => (
@@ -199,97 +208,142 @@ export function HomeWizardSection({ locale, copy }: HomeWizardSectionProps) {
                 {chip.label}
               </button>
             ))}
-        </div>
+        </nav>
 
         {step === 'activityTypes' ? (
-          <div className="mt-8">
-            <h2 className="text-2xl font-semibold">{copy.activityQuestion}</h2>
+          <form
+            className="mt-8"
+            onSubmit={(event) => {
+              event.preventDefault();
+              confirmActivityTypes();
+            }}
+          >
+            <fieldset>
+              <legend className="text-2xl font-semibold">
+                {copy.activityQuestion}
+              </legend>
+              <ul className="mt-4 space-y-2">
+                {homeWizardChoices.activityTypes.map((option) => {
+                  const inputId = `activity-type-${option.id}`;
+                  return (
+                    <li key={option.id}>
+                      <label htmlFor={inputId} className={optionClassName}>
+                        <input
+                          id={inputId}
+                          type="checkbox"
+                          name="activityType"
+                          value={option.id}
+                          checked={selectedActivityTypeIds.has(option.id)}
+                          onChange={(event) => {
+                            toggleActivityType(option.id, event.target.checked);
+                          }}
+                        />
+                        <span>{labelForLocale(option.labels, locale)}</span>
+                      </label>
+                    </li>
+                  );
+                })}
+              </ul>
+            </fieldset>
+            <button
+              type="submit"
+              className="mt-6 rounded-lg bg-brand-500 px-4 py-2 text-white disabled:opacity-50"
+              disabled={selectedActivityTypeIds.size === 0}
+            >
+              {copy.continueLabel}
+            </button>
+          </form>
+        ) : null}
+
+        {step === 'ageGroup' ? (
+          <fieldset className="mt-8">
+            <legend className="text-2xl font-semibold">{copy.ageQuestion}</legend>
             <ul className="mt-4 space-y-2">
-              {homeWizardChoices.activityTypes.map((option) => {
-                const selected = selectedActivityTypeIds.has(option.id);
+              {homeWizardChoices.ageGroups.map((option) => {
+                const inputId = `age-group-${option.id}`;
                 return (
                   <li key={option.id}>
-                    <button
-                      type="button"
-                      className={
-                        'w-full rounded-lg border px-4 py-3 text-left ' +
-                        (selected
-                          ? 'border-brand-500 bg-brand-50'
-                          : 'border-slate-200')
-                      }
-                      onClick={() => toggleActivityType(option.id)}
-                    >
-                      {labelForLocale(option.labels, locale)}
-                    </button>
+                    <label htmlFor={inputId} className={optionClassName}>
+                      <input
+                        id={inputId}
+                        type="radio"
+                        name="ageGroup"
+                        value={option.id}
+                        checked={selectedAgeGroupId === option.id}
+                        onChange={() => {
+                          void selectAgeGroup(option.id);
+                        }}
+                      />
+                      <span>{labelForLocale(option.labels, locale)}</span>
+                    </label>
                   </li>
                 );
               })}
             </ul>
-            <button
-              type="button"
-              className="mt-6 rounded-lg bg-brand-500 px-4 py-2 text-white disabled:opacity-50"
-              disabled={selectedActivityTypeIds.size === 0}
-              onClick={confirmActivityTypes}
-            >
-              {copy.continueLabel}
-            </button>
-          </div>
-        ) : null}
-
-        {step === 'ageGroup' ? (
-          <div className="mt-8">
-            <h2 className="text-2xl font-semibold">{copy.ageQuestion}</h2>
-            <ul className="mt-4 space-y-2">
-              {homeWizardChoices.ageGroups.map((option) => (
-                <li key={option.id}>
-                  <button
-                    type="button"
-                    className="w-full rounded-lg border border-slate-200 px-4 py-3 text-left"
-                    onClick={() => selectAgeGroup(option.id)}
-                  >
-                    {labelForLocale(option.labels, locale)}
-                  </button>
-                </li>
-              ))}
-            </ul>
-          </div>
+          </fieldset>
         ) : null}
 
         {step === 'region' ? (
-          <div className="mt-8">
-            <h2 className="text-2xl font-semibold">{copy.regionQuestion}</h2>
+          <fieldset className="mt-8">
+            <legend className="text-2xl font-semibold">
+              {copy.regionQuestion}
+            </legend>
             {isLoading ? (
-              <p className="mt-4 text-sm text-slate-600">{copy.loadingLabel}</p>
+              <p
+                className="mt-4 text-sm text-slate-600"
+                aria-live="polite"
+              >
+                {copy.loadingLabel}
+              </p>
             ) : null}
             <ul className="mt-4 space-y-2">
-              {homeWizardChoices.regions.map((option) => (
-                <li key={option.id}>
-                  <button
-                    type="button"
-                    className="w-full rounded-lg border border-slate-200 px-4 py-3 text-left"
-                    onClick={() => selectRegion(option.id)}
-                  >
-                    {labelForLocale(option.labels, locale)}
-                  </button>
-                </li>
-              ))}
+              {homeWizardChoices.regions.map((option) => {
+                const inputId = `region-${option.id}`;
+                return (
+                  <li key={option.id}>
+                    <label htmlFor={inputId} className={optionClassName}>
+                      <input
+                        id={inputId}
+                        type="radio"
+                        name="region"
+                        value={option.id}
+                        checked={selectedRegionId === option.id}
+                        onChange={() => selectRegion(option.id)}
+                      />
+                      <span>{labelForLocale(option.labels, locale)}</span>
+                    </label>
+                  </li>
+                );
+              })}
             </ul>
-          </div>
+          </fieldset>
         ) : null}
 
         {step === 'results' ? (
           <div className="mt-8">
-            <label className="block text-sm font-medium text-slate-700">
-              {copy.searchPlaceholder}
+            <form
+              role="search"
+              onSubmit={(event) => event.preventDefault()}
+            >
+              <label
+                htmlFor={searchInputId}
+                className="block text-sm font-medium text-slate-700"
+              >
+                {copy.searchPlaceholder}
+              </label>
               <input
+                id={searchInputId}
                 type="search"
+                name="q"
+                autoComplete="off"
+                enterKeyHint="search"
                 className="mt-2 w-full rounded-lg border border-slate-300 px-3 py-2"
                 value={searchQuery}
                 onChange={(event) => updateSearchQuery(event.target.value)}
               />
-            </label>
+            </form>
             {errorMessage ? (
-              <div className="mt-4">
+              <div className="mt-4" role="alert">
                 <p className="text-sm text-red-700">{errorMessage}</p>
                 <button
                   type="button"
@@ -308,12 +362,19 @@ export function HomeWizardSection({ locale, copy }: HomeWizardSectionProps) {
               </div>
             ) : null}
             {isLoading ? (
-              <p className="mt-4 text-sm text-slate-600">{copy.loadingLabel}</p>
+              <p
+                className="mt-4 text-sm text-slate-600"
+                aria-live="polite"
+              >
+                {copy.loadingLabel}
+              </p>
             ) : null}
             {!isLoading && filteredItems.length === 0 ? (
-              <p className="mt-4 text-sm text-slate-600">{copy.emptyLabel}</p>
+              <p className="mt-4 text-sm text-slate-600" aria-live="polite">
+                {copy.emptyLabel}
+              </p>
             ) : null}
-            <ul className="mt-4 space-y-3">
+            <ul className="mt-4 space-y-3" aria-live="polite">
               {filteredItems.map((item) => (
                 <li
                   key={item.activity.id}

--- a/apps/public_www/src/components/sections/home-wizard/home-wizard-section.tsx
+++ b/apps/public_www/src/components/sections/home-wizard/home-wizard-section.tsx
@@ -1,0 +1,334 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+
+import type { Locale } from '@/content';
+import {
+  homeWizardChoices,
+  labelForLocale,
+} from '@/lib/home-wizard/choices';
+import { filterWizardResults } from '@/lib/home-wizard/filter-results';
+import {
+  fetchActivitiesForWizard,
+  type ActivitySearchResult,
+} from '@/lib/home-wizard/search-client';
+
+type WizardStep = 'activityTypes' | 'ageGroup' | 'region' | 'results';
+
+interface HomeWizardCopy {
+  readonly activityQuestion: string;
+  readonly ageQuestion: string;
+  readonly regionQuestion: string;
+  readonly continueLabel: string;
+  readonly searchPlaceholder: string;
+  readonly loadingLabel: string;
+  readonly emptyLabel: string;
+  readonly errorLabel: string;
+  readonly retryLabel: string;
+}
+
+interface HomeWizardSectionProps {
+  readonly locale: Locale;
+  readonly copy: HomeWizardCopy;
+}
+
+export function HomeWizardSection({ locale, copy }: HomeWizardSectionProps) {
+  const [step, setStep] = useState<WizardStep>('activityTypes');
+  const [selectedActivityTypeIds, setSelectedActivityTypeIds] = useState<
+    ReadonlySet<string>
+  >(() => new Set());
+  const [selectedAgeGroupId, setSelectedAgeGroupId] = useState<string | null>(
+    null,
+  );
+  const [selectedRegionId, setSelectedRegionId] = useState<string | null>(null);
+  const [prefetchedItems, setPrefetchedItems] = useState<
+    readonly ActivitySearchResult[]
+  >([]);
+  const [filteredItems, setFilteredItems] = useState<
+    readonly ActivitySearchResult[]
+  >([]);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const selectedRegion = useMemo(() => {
+    if (!selectedRegionId) {
+      return null;
+    }
+    return homeWizardChoices.regions.find(
+      (region) => region.id === selectedRegionId,
+    );
+  }, [selectedRegionId]);
+
+  const applyFilters = useCallback(
+    (
+      items: readonly ActivitySearchResult[],
+      regionAreaId: string,
+      query: string,
+    ) => {
+      setFilteredItems(filterWizardResults(items, regionAreaId, query));
+    },
+    [],
+  );
+
+  const prefetchResults = useCallback(
+    async (ageGroupId: string, activityTypeIds: ReadonlySet<string>) => {
+      const ageGroup = homeWizardChoices.ageGroups.find(
+        (group) => group.id === ageGroupId,
+      );
+      if (!ageGroup) {
+        return;
+      }
+      const categoryIds = homeWizardChoices.activityTypes
+        .filter((type) => activityTypeIds.has(type.id))
+        .map((type) => type.categoryId);
+      setIsLoading(true);
+      setErrorMessage(null);
+      try {
+        const response = await fetchActivitiesForWizard({
+          age: ageGroup.searchAge,
+          categoryIds,
+        });
+        setPrefetchedItems(response.items);
+      } catch {
+        setErrorMessage(copy.errorLabel);
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [copy.errorLabel],
+  );
+
+  const toggleActivityType = (activityTypeId: string) => {
+    setSelectedActivityTypeIds((current) => {
+      const next = new Set(current);
+      if (next.has(activityTypeId)) {
+        next.delete(activityTypeId);
+      } else {
+        next.add(activityTypeId);
+      }
+      return next;
+    });
+    setSelectedAgeGroupId(null);
+    setSelectedRegionId(null);
+    setPrefetchedItems([]);
+    setFilteredItems([]);
+    setStep('activityTypes');
+  };
+
+  const confirmActivityTypes = () => {
+    if (selectedActivityTypeIds.size === 0) {
+      return;
+    }
+    setStep('ageGroup');
+  };
+
+  const selectAgeGroup = async (ageGroupId: string) => {
+    setSelectedAgeGroupId(ageGroupId);
+    setSelectedRegionId(null);
+    setFilteredItems([]);
+    setStep('region');
+    await prefetchResults(ageGroupId, selectedActivityTypeIds);
+  };
+
+  const selectRegion = (regionId: string) => {
+    const region = homeWizardChoices.regions.find((item) => item.id === regionId);
+    if (!region) {
+      return;
+    }
+    setSelectedRegionId(regionId);
+    setStep('results');
+    applyFilters(prefetchedItems, region.areaId, searchQuery);
+  };
+
+  const updateSearchQuery = (value: string) => {
+    setSearchQuery(value);
+    if (!selectedRegion) {
+      return;
+    }
+    applyFilters(prefetchedItems, selectedRegion.areaId, value);
+  };
+
+  const summaryChips = [
+    {
+      key: 'activity',
+      label: homeWizardChoices.activityTypes
+        .filter((type) => selectedActivityTypeIds.has(type.id))
+        .map((type) => labelForLocale(type.labels, locale))
+        .join(', '),
+      visible: selectedActivityTypeIds.size > 0,
+      onClick: () => setStep('activityTypes'),
+    },
+    {
+      key: 'age',
+      label: homeWizardChoices.ageGroups
+        .filter((group) => group.id === selectedAgeGroupId)
+        .map((group) => labelForLocale(group.labels, locale))
+        .join(''),
+      visible: selectedAgeGroupId !== null,
+      onClick: () => setStep('ageGroup'),
+    },
+    {
+      key: 'region',
+      label: homeWizardChoices.regions
+        .filter((region) => region.id === selectedRegionId)
+        .map((region) => labelForLocale(region.labels, locale))
+        .join(''),
+      visible: selectedRegionId !== null,
+      onClick: () => setStep('region'),
+    },
+  ];
+
+  return (
+    <section
+      id="home-wizard"
+      className="bg-white text-slate-900"
+      data-section-id="home-wizard"
+    >
+      <div className="mx-auto max-w-3xl px-4 py-10 sm:px-6">
+        <div className="flex flex-wrap gap-2">
+          {summaryChips
+            .filter((chip) => chip.visible)
+            .map((chip) => (
+              <button
+                key={chip.key}
+                type="button"
+                className="rounded-full border border-slate-300 px-3 py-1 text-sm"
+                onClick={chip.onClick}
+              >
+                {chip.label}
+              </button>
+            ))}
+        </div>
+
+        {step === 'activityTypes' ? (
+          <div className="mt-8">
+            <h2 className="text-2xl font-semibold">{copy.activityQuestion}</h2>
+            <ul className="mt-4 space-y-2">
+              {homeWizardChoices.activityTypes.map((option) => {
+                const selected = selectedActivityTypeIds.has(option.id);
+                return (
+                  <li key={option.id}>
+                    <button
+                      type="button"
+                      className={
+                        'w-full rounded-lg border px-4 py-3 text-left ' +
+                        (selected
+                          ? 'border-brand-500 bg-brand-50'
+                          : 'border-slate-200')
+                      }
+                      onClick={() => toggleActivityType(option.id)}
+                    >
+                      {labelForLocale(option.labels, locale)}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+            <button
+              type="button"
+              className="mt-6 rounded-lg bg-brand-500 px-4 py-2 text-white disabled:opacity-50"
+              disabled={selectedActivityTypeIds.size === 0}
+              onClick={confirmActivityTypes}
+            >
+              {copy.continueLabel}
+            </button>
+          </div>
+        ) : null}
+
+        {step === 'ageGroup' ? (
+          <div className="mt-8">
+            <h2 className="text-2xl font-semibold">{copy.ageQuestion}</h2>
+            <ul className="mt-4 space-y-2">
+              {homeWizardChoices.ageGroups.map((option) => (
+                <li key={option.id}>
+                  <button
+                    type="button"
+                    className="w-full rounded-lg border border-slate-200 px-4 py-3 text-left"
+                    onClick={() => selectAgeGroup(option.id)}
+                  >
+                    {labelForLocale(option.labels, locale)}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+
+        {step === 'region' ? (
+          <div className="mt-8">
+            <h2 className="text-2xl font-semibold">{copy.regionQuestion}</h2>
+            {isLoading ? (
+              <p className="mt-4 text-sm text-slate-600">{copy.loadingLabel}</p>
+            ) : null}
+            <ul className="mt-4 space-y-2">
+              {homeWizardChoices.regions.map((option) => (
+                <li key={option.id}>
+                  <button
+                    type="button"
+                    className="w-full rounded-lg border border-slate-200 px-4 py-3 text-left"
+                    onClick={() => selectRegion(option.id)}
+                  >
+                    {labelForLocale(option.labels, locale)}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+
+        {step === 'results' ? (
+          <div className="mt-8">
+            <label className="block text-sm font-medium text-slate-700">
+              {copy.searchPlaceholder}
+              <input
+                type="search"
+                className="mt-2 w-full rounded-lg border border-slate-300 px-3 py-2"
+                value={searchQuery}
+                onChange={(event) => updateSearchQuery(event.target.value)}
+              />
+            </label>
+            {errorMessage ? (
+              <div className="mt-4">
+                <p className="text-sm text-red-700">{errorMessage}</p>
+                <button
+                  type="button"
+                  className="mt-2 text-sm font-medium text-brand-600"
+                  onClick={() => {
+                    if (selectedAgeGroupId) {
+                      void prefetchResults(
+                        selectedAgeGroupId,
+                        selectedActivityTypeIds,
+                      );
+                    }
+                  }}
+                >
+                  {copy.retryLabel}
+                </button>
+              </div>
+            ) : null}
+            {isLoading ? (
+              <p className="mt-4 text-sm text-slate-600">{copy.loadingLabel}</p>
+            ) : null}
+            {!isLoading && filteredItems.length === 0 ? (
+              <p className="mt-4 text-sm text-slate-600">{copy.emptyLabel}</p>
+            ) : null}
+            <ul className="mt-4 space-y-3">
+              {filteredItems.map((item) => (
+                <li
+                  key={item.activity.id}
+                  className="rounded-lg border border-slate-200 px-4 py-3"
+                >
+                  <p className="font-medium">{item.activity.name}</p>
+                  <p className="text-sm text-slate-600">
+                    {item.organization.name}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/apps/public_www/src/content/en.json
+++ b/apps/public_www/src/content/en.json
@@ -66,6 +66,17 @@
       }
     }
   },
+  "homeWizard": {
+    "activityQuestion": "What activities are you looking for?",
+    "ageQuestion": "How old is your child?",
+    "regionQuestion": "Which area is near you?",
+    "continueLabel": "Continue",
+    "searchPlaceholder": "Search activities, organizations...",
+    "loadingLabel": "Loading activities...",
+    "emptyLabel": "No activities found. Try changing your choices.",
+    "errorLabel": "Unable to load activities.",
+    "retryLabel": "Try again"
+  },
   "pages": {
     "home": {
       "body": {
@@ -77,12 +88,21 @@
                 "colStart": 1,
                 "colSpan": 12,
                 "props": {
-                  "eyebrow": "Coming soon",
-                  "primaryCtaLabel": "Learn more",
-                  "primaryCtaHref": "#features",
+                  "eyebrow": "Find activities",
+                  "primaryCtaLabel": "Start searching",
+                  "primaryCtaHref": "#home-wizard",
                   "secondaryCtaLabel": "Get in touch",
                   "secondaryCtaHref": "#contact"
                 }
+              }
+            ]
+          },
+          {
+            "cells": [
+              {
+                "component": "homeWizard",
+                "colStart": 1,
+                "colSpan": 12
               }
             ]
           },

--- a/apps/public_www/src/content/zh-HK.json
+++ b/apps/public_www/src/content/zh-HK.json
@@ -66,6 +66,17 @@
       }
     }
   },
+  "homeWizard": {
+    "activityQuestion": "你想找甚麼類型的活動？",
+    "ageQuestion": "你的孩子幾歲？",
+    "regionQuestion": "你想找哪區附近的活動？",
+    "continueLabel": "繼續",
+    "searchPlaceholder": "搜尋活動、機構...",
+    "loadingLabel": "正在載入活動...",
+    "emptyLabel": "找不到活動，請嘗試更改選項。",
+    "errorLabel": "無法載入活動。",
+    "retryLabel": "重試"
+  },
   "pages": {
     "home": {
       "body": {
@@ -77,12 +88,21 @@
                 "colStart": 1,
                 "colSpan": 12,
                 "props": {
-                  "eyebrow": "即將推出",
-                  "primaryCtaLabel": "了解更多",
-                  "primaryCtaHref": "#features",
+                  "eyebrow": "尋找活動",
+                  "primaryCtaLabel": "開始搜尋",
+                  "primaryCtaHref": "#home-wizard",
                   "secondaryCtaLabel": "聯絡我們",
                   "secondaryCtaHref": "#contact"
                 }
+              }
+            ]
+          },
+          {
+            "cells": [
+              {
+                "component": "homeWizard",
+                "colStart": 1,
+                "colSpan": 12
               }
             ]
           },

--- a/apps/public_www/src/data/home_wizard_choices.json
+++ b/apps/public_www/src/data/home_wizard_choices.json
@@ -1,0 +1,103 @@
+{
+  "version": 1,
+  "activityTypes": [
+    {
+      "id": "workshop",
+      "categoryId": "c1111111-1111-1111-1111-111111111101",
+      "labels": {
+        "en": "Workshop",
+        "zh-HK": "工作坊"
+      }
+    },
+    {
+      "id": "class",
+      "categoryId": "c1111111-1111-1111-1111-111111111102",
+      "labels": {
+        "en": "Class",
+        "zh-HK": "課程"
+      }
+    },
+    {
+      "id": "outdoor",
+      "categoryId": "c1111111-1111-1111-1111-111111111103",
+      "labels": {
+        "en": "Outdoor activity",
+        "zh-HK": "戶外活動"
+      }
+    },
+    {
+      "id": "indoor",
+      "categoryId": "c1111111-1111-1111-1111-111111111104",
+      "labels": {
+        "en": "Indoor fun",
+        "zh-HK": "室內玩樂"
+      }
+    }
+  ],
+  "ageGroups": [
+    {
+      "id": "1-3",
+      "searchAge": 2,
+      "minAge": 1,
+      "maxAge": 3,
+      "labels": {
+        "en": "1–3 years",
+        "zh-HK": "1–3歲"
+      }
+    },
+    {
+      "id": "3-6",
+      "searchAge": 4,
+      "minAge": 3,
+      "maxAge": 6,
+      "labels": {
+        "en": "3–6 years",
+        "zh-HK": "3–6歲"
+      }
+    },
+    {
+      "id": "6-12",
+      "searchAge": 9,
+      "minAge": 6,
+      "maxAge": 12,
+      "labels": {
+        "en": "6–12 years",
+        "zh-HK": "6–12歲"
+      }
+    }
+  ],
+  "regions": [
+    {
+      "id": "hong_kong_island",
+      "areaId": "a1111111-1111-1111-1111-111111111101",
+      "labels": {
+        "en": "Hong Kong Island",
+        "zh-HK": "香港島"
+      }
+    },
+    {
+      "id": "kowloon",
+      "areaId": "a1111111-1111-1111-1111-111111111102",
+      "labels": {
+        "en": "Kowloon",
+        "zh-HK": "九龍"
+      }
+    },
+    {
+      "id": "new_territories",
+      "areaId": "a1111111-1111-1111-1111-111111111103",
+      "labels": {
+        "en": "New Territories",
+        "zh-HK": "新界"
+      }
+    },
+    {
+      "id": "islands",
+      "areaId": "a1111111-1111-1111-1111-111111111104",
+      "labels": {
+        "en": "Islands",
+        "zh-HK": "離島"
+      }
+    }
+  ]
+}

--- a/apps/public_www/src/lib/home-wizard/choices.ts
+++ b/apps/public_www/src/lib/home-wizard/choices.ts
@@ -1,0 +1,43 @@
+import choicesJson from '../../../../shared/home_wizard/home_wizard_choices.json';
+
+export interface WizardLabels {
+  readonly en: string;
+  readonly 'zh-HK': string;
+}
+
+export interface WizardActivityTypeOption {
+  readonly id: string;
+  readonly categoryId: string;
+  readonly labels: WizardLabels;
+}
+
+export interface WizardAgeGroupOption {
+  readonly id: string;
+  readonly searchAge: number;
+  readonly labels: WizardLabels;
+}
+
+export interface WizardRegionOption {
+  readonly id: string;
+  readonly areaId: string;
+  readonly labels: WizardLabels;
+}
+
+export interface HomeWizardChoices {
+  readonly version: number;
+  readonly activityTypes: readonly WizardActivityTypeOption[];
+  readonly ageGroups: readonly WizardAgeGroupOption[];
+  readonly regions: readonly WizardRegionOption[];
+}
+
+export const homeWizardChoices = choicesJson as HomeWizardChoices;
+
+export function labelForLocale(
+  labels: WizardLabels,
+  locale: string,
+): string {
+  if (locale === 'zh-HK' && labels['zh-HK'].trim() !== '') {
+    return labels['zh-HK'];
+  }
+  return labels.en;
+}

--- a/apps/public_www/src/lib/home-wizard/choices.ts
+++ b/apps/public_www/src/lib/home-wizard/choices.ts
@@ -1,4 +1,4 @@
-import choicesJson from '../../../../shared/home_wizard/home_wizard_choices.json';
+import choicesJson from '@/data/home_wizard_choices.json';
 
 export interface WizardLabels {
   readonly en: string;

--- a/apps/public_www/src/lib/home-wizard/filter-results.ts
+++ b/apps/public_www/src/lib/home-wizard/filter-results.ts
@@ -1,0 +1,25 @@
+import type { ActivitySearchResult } from '@/lib/home-wizard/search-client';
+
+export function filterWizardResults(
+  items: readonly ActivitySearchResult[],
+  regionAreaId: string,
+  searchQuery: string,
+): readonly ActivitySearchResult[] {
+  const query = searchQuery.trim().toLowerCase();
+  return items.filter((item) => {
+    if (item.location.regionAreaId !== regionAreaId) {
+      return false;
+    }
+    if (query === '') {
+      return true;
+    }
+    const haystack = [
+      item.activity.name,
+      item.activity.description ?? '',
+      item.organization.name,
+    ]
+      .join(' ')
+      .toLowerCase();
+    return haystack.includes(query);
+  });
+}

--- a/apps/public_www/src/lib/home-wizard/search-client.ts
+++ b/apps/public_www/src/lib/home-wizard/search-client.ts
@@ -1,0 +1,93 @@
+import { getSearchConfig } from '@/lib/site-config';
+
+export interface SearchActivity {
+  readonly id: string;
+  readonly name: string;
+  readonly description: string | null;
+  readonly categoryId: string | null;
+}
+
+export interface SearchLocation {
+  readonly areaId: string;
+  readonly regionAreaId: string | null;
+}
+
+export interface SearchOrganization {
+  readonly name: string;
+}
+
+export interface ActivitySearchResult {
+  readonly activity: SearchActivity;
+  readonly organization: SearchOrganization;
+  readonly location: SearchLocation;
+}
+
+export interface ActivitySearchResponse {
+  readonly items: readonly ActivitySearchResult[];
+}
+
+export async function fetchActivitiesForWizard(params: {
+  readonly age: number;
+  readonly categoryIds: readonly string[];
+}): Promise<ActivitySearchResponse> {
+  const config = getSearchConfig();
+  if (!config.apiBaseUrl) {
+    throw new Error('Search API is not configured.');
+  }
+
+  const url = new URL('/v1/activities/search', config.apiBaseUrl);
+  url.searchParams.set('age', String(params.age));
+  url.searchParams.set('limit', '200');
+  for (const categoryId of params.categoryIds) {
+    url.searchParams.append('category_id', categoryId);
+  }
+
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+  };
+  if (config.apiKey) {
+    headers['x-api-key'] = config.apiKey;
+  }
+  if (config.attestationToken) {
+    headers['x-device-attestation'] = config.attestationToken;
+  }
+
+  const response = await fetch(url.toString(), { headers });
+  if (!response.ok) {
+    throw new Error(`Search failed with status ${response.status}`);
+  }
+
+  const payload = (await response.json()) as {
+    items?: Array<{
+      activity: {
+        id: string;
+        name: string;
+        description: string | null;
+        category_id?: string | null;
+      };
+      organization: { name: string };
+      location: {
+        area_id: string;
+        region_area_id?: string | null;
+      };
+    }>;
+  };
+
+  const items = (payload.items ?? []).map((item) => ({
+    activity: {
+      id: item.activity.id,
+      name: item.activity.name,
+      description: item.activity.description,
+      categoryId: item.activity.category_id ?? null,
+    },
+    organization: {
+      name: item.organization.name,
+    },
+    location: {
+      areaId: item.location.area_id,
+      regionAreaId: item.location.region_area_id ?? null,
+    },
+  }));
+
+  return { items };
+}

--- a/apps/public_www/src/lib/page-grid/types.ts
+++ b/apps/public_www/src/lib/page-grid/types.ts
@@ -2,6 +2,7 @@ export const PAGE_GRID_MAX_COLUMNS = 12;
 
 export const PAGE_GRID_COMPONENT_IDS = [
   'hero',
+  'homeWizard',
   'features',
   'richText',
 ] as const;

--- a/apps/public_www/src/lib/site-config.ts
+++ b/apps/public_www/src/lib/site-config.ts
@@ -4,12 +4,19 @@ interface SiteContact {
   readonly instagramUrl: string;
 }
 
+export interface SearchConfig {
+  readonly apiBaseUrl: string;
+  readonly apiKey: string;
+  readonly attestationToken: string;
+}
+
 export interface SiteConfig {
   readonly siteOrigin: string;
   readonly siteName: string;
   readonly siteTagline: string;
   readonly stagingBadgeEnabled: boolean;
   readonly contact: SiteContact;
+  readonly search: SearchConfig;
 }
 
 export interface PublicSiteConfig {
@@ -38,6 +45,15 @@ export function getSiteConfig(): SiteConfig {
       whatsappUrl: readPublicEnv('NEXT_PUBLIC_WHATSAPP_URL'),
       instagramUrl: readPublicEnv('NEXT_PUBLIC_INSTAGRAM_URL'),
     },
+    search: getSearchConfig(),
+  };
+}
+
+export function getSearchConfig(): SearchConfig {
+  return {
+    apiBaseUrl: readPublicEnv('NEXT_PUBLIC_SEARCH_API_BASE_URL'),
+    apiKey: readPublicEnv('NEXT_PUBLIC_SEARCH_API_KEY'),
+    attestationToken: readPublicEnv('NEXT_PUBLIC_DEVICE_ATTESTATION_TOKEN'),
   };
 }
 

--- a/apps/public_www/tests/app/page.test.tsx
+++ b/apps/public_www/tests/app/page.test.tsx
@@ -30,16 +30,17 @@ describe('MarketingPage', () => {
     expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
       content.hero.title,
     );
-    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
-      content.features.title,
-    );
+    expect(
+      screen.getByText(content.homeWizard.activityQuestion),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: content.features.title })).toBeInTheDocument();
     expect(screen.getByRole('navigation', { name: 'Main' })).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: content.navbar.openNavigationMenuAriaLabel }),
     ).toBeInTheDocument();
 
     const bleedRows = document.querySelectorAll('.page-body-grid__row--bleed');
-    expect(bleedRows.length).toBe(2);
+    expect(bleedRows.length).toBe(3);
 
     const gridCells = document.querySelectorAll('.page-body-grid__cell');
     expect(gridCells.length).toBeGreaterThan(0);

--- a/apps/public_www/tests/lib/home-wizard-filter.test.ts
+++ b/apps/public_www/tests/lib/home-wizard-filter.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { filterWizardResults } from '@/lib/home-wizard/filter-results';
+import type { ActivitySearchResult } from '@/lib/home-wizard/search-client';
+
+const sampleItems: readonly ActivitySearchResult[] = [
+  {
+    activity: {
+      id: '1',
+      name: 'Painting',
+      description: 'Art class',
+      categoryId: 'c1',
+    },
+    organization: { name: 'Studio' },
+    location: {
+      areaId: 'district-1',
+      regionAreaId: 'region-hk-island',
+    },
+  },
+  {
+    activity: {
+      id: '2',
+      name: 'Dance',
+      description: 'Movement',
+      categoryId: 'c2',
+    },
+    organization: { name: 'Dance Co' },
+    location: {
+      areaId: 'district-2',
+      regionAreaId: 'region-kowloon',
+    },
+  },
+];
+
+describe('filterWizardResults', () => {
+  it('filters by macro region', () => {
+    const filtered = filterWizardResults(
+      sampleItems,
+      'region-hk-island',
+      '',
+    );
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0]?.activity.name).toBe('Painting');
+  });
+
+  it('applies free-text search on filtered region results', () => {
+    const filtered = filterWizardResults(
+      sampleItems,
+      'region-kowloon',
+      'dance',
+    );
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0]?.activity.name).toBe('Dance');
+  });
+});

--- a/apps/siutindei_app/assets/home_wizard/home_wizard_choices.json
+++ b/apps/siutindei_app/assets/home_wizard/home_wizard_choices.json
@@ -1,0 +1,103 @@
+{
+  "version": 1,
+  "activityTypes": [
+    {
+      "id": "workshop",
+      "categoryId": "c1111111-1111-1111-1111-111111111101",
+      "labels": {
+        "en": "Workshop",
+        "zh-HK": "工作坊"
+      }
+    },
+    {
+      "id": "class",
+      "categoryId": "c1111111-1111-1111-1111-111111111102",
+      "labels": {
+        "en": "Class",
+        "zh-HK": "課程"
+      }
+    },
+    {
+      "id": "outdoor",
+      "categoryId": "c1111111-1111-1111-1111-111111111103",
+      "labels": {
+        "en": "Outdoor activity",
+        "zh-HK": "戶外活動"
+      }
+    },
+    {
+      "id": "indoor",
+      "categoryId": "c1111111-1111-1111-1111-111111111104",
+      "labels": {
+        "en": "Indoor fun",
+        "zh-HK": "室內玩樂"
+      }
+    }
+  ],
+  "ageGroups": [
+    {
+      "id": "1-3",
+      "searchAge": 2,
+      "minAge": 1,
+      "maxAge": 3,
+      "labels": {
+        "en": "1–3 years",
+        "zh-HK": "1–3歲"
+      }
+    },
+    {
+      "id": "3-6",
+      "searchAge": 4,
+      "minAge": 3,
+      "maxAge": 6,
+      "labels": {
+        "en": "3–6 years",
+        "zh-HK": "3–6歲"
+      }
+    },
+    {
+      "id": "6-12",
+      "searchAge": 9,
+      "minAge": 6,
+      "maxAge": 12,
+      "labels": {
+        "en": "6–12 years",
+        "zh-HK": "6–12歲"
+      }
+    }
+  ],
+  "regions": [
+    {
+      "id": "hong_kong_island",
+      "areaId": "a1111111-1111-1111-1111-111111111101",
+      "labels": {
+        "en": "Hong Kong Island",
+        "zh-HK": "香港島"
+      }
+    },
+    {
+      "id": "kowloon",
+      "areaId": "a1111111-1111-1111-1111-111111111102",
+      "labels": {
+        "en": "Kowloon",
+        "zh-HK": "九龍"
+      }
+    },
+    {
+      "id": "new_territories",
+      "areaId": "a1111111-1111-1111-1111-111111111103",
+      "labels": {
+        "en": "New Territories",
+        "zh-HK": "新界"
+      }
+    },
+    {
+      "id": "islands",
+      "areaId": "a1111111-1111-1111-1111-111111111104",
+      "labels": {
+        "en": "Islands",
+        "zh-HK": "離島"
+      }
+    }
+  ]
+}

--- a/apps/siutindei_app/lib/app.dart
+++ b/apps/siutindei_app/lib/app.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'config/tokens/tokens.dart';
-import 'features/search/search.dart';
+import 'features/home_wizard/screens/home_wizard_screen.dart';
 import 'viewmodels/auth_viewmodel.dart';
 
 /// Main application widget.
@@ -54,7 +54,7 @@ class App extends ConsumerWidget {
       debugShowCheckedModeBanner: false,
       home: authState.isLoading
           ? const Scaffold(body: Center(child: CircularProgressIndicator()))
-          : const SearchScreen(),
+          : const HomeWizardScreen(),
     );
   }
 }

--- a/apps/siutindei_app/lib/data/mappers/activity_mapper.dart
+++ b/apps/siutindei_app/lib/data/mappers/activity_mapper.dart
@@ -16,6 +16,7 @@ class ActivityMapper {
       description: model.description,
       ageMin: model.ageMin,
       ageMax: model.ageMax,
+      categoryId: model.categoryId,
     );
   }
 
@@ -35,6 +36,7 @@ class ActivityMapper {
     return LocationEntity(
       id: model.id,
       areaId: model.areaId,
+      regionAreaId: model.regionAreaId,
       address: model.address,
       latitude: model.lat,
       longitude: model.lng,
@@ -104,6 +106,7 @@ class SearchFiltersMapper {
       searchQuery: filters.searchQuery,
       age: filters.age,
       areaId: filters.areaId,
+      categoryIds: filters.categoryIds,
       pricingType: filters.pricingType?.toApiString(),
       priceMin: filters.priceMin,
       priceMax: filters.priceMax,

--- a/apps/siutindei_app/lib/domain/entities/activity.dart
+++ b/apps/siutindei_app/lib/domain/entities/activity.dart
@@ -9,6 +9,7 @@ class ActivityEntity {
     this.description,
     this.ageMin,
     this.ageMax,
+    this.categoryId,
   });
 
   final String id;
@@ -16,6 +17,7 @@ class ActivityEntity {
   final String? description;
   final int? ageMin;
   final int? ageMax;
+  final String? categoryId;
 
   /// Returns a display string for the age range.
   String? get ageRangeDisplay {
@@ -82,6 +84,7 @@ class LocationEntity {
   const LocationEntity({
     required this.id,
     required this.areaId,
+    this.regionAreaId,
     this.address,
     this.latitude,
     this.longitude,
@@ -89,6 +92,7 @@ class LocationEntity {
 
   final String id;
   final String areaId;
+  final String? regionAreaId;
   final String? address;
   final double? latitude;
   final double? longitude;

--- a/apps/siutindei_app/lib/domain/entities/search.dart
+++ b/apps/siutindei_app/lib/domain/entities/search.dart
@@ -63,6 +63,7 @@ class SearchFilters {
     this.searchQuery,
     this.age,
     this.areaId,
+    this.categoryIds = const [],
     this.pricingType,
     this.priceMin,
     this.priceMax,
@@ -81,6 +82,7 @@ class SearchFilters {
   final String? searchQuery;
   final int? age;
   final String? areaId;
+  final List<String> categoryIds;
   final PricingType? pricingType;
   final double? priceMin;
   final double? priceMax;
@@ -99,6 +101,7 @@ class SearchFilters {
   bool get hasActiveFilters =>
       age != null ||
       areaId != null ||
+      categoryIds.isNotEmpty ||
       pricingType != null ||
       priceMin != null ||
       priceMax != null ||
@@ -131,6 +134,7 @@ class SearchFilters {
     String? searchQuery,
     int? age,
     String? areaId,
+    List<String>? categoryIds,
     PricingType? pricingType,
     double? priceMin,
     double? priceMax,
@@ -163,6 +167,7 @@ class SearchFilters {
       searchQuery: clearSearchQuery ? null : (searchQuery ?? this.searchQuery),
       age: clearAge ? null : (age ?? this.age),
       areaId: clearAreaId ? null : (areaId ?? this.areaId),
+      categoryIds: categoryIds ?? this.categoryIds,
       pricingType: clearPricingType ? null : (pricingType ?? this.pricingType),
       priceMin: clearPriceMin ? null : (priceMin ?? this.priceMin),
       priceMax: clearPriceMax ? null : (priceMax ?? this.priceMax),

--- a/apps/siutindei_app/lib/features/home_wizard/home_wizard_viewmodel.dart
+++ b/apps/siutindei_app/lib/features/home_wizard/home_wizard_viewmodel.dart
@@ -1,0 +1,256 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/core.dart';
+import '../../data/providers.dart';
+import '../../domain/entities/entities.dart';
+import '../../domain/use_cases/use_cases.dart';
+import 'models/home_wizard_choices.dart';
+
+enum HomeWizardStep { activityTypes, ageGroup, region, results }
+
+enum HomeWizardPrefetchStatus { idle, loading, ready, error }
+
+@immutable
+class HomeWizardState {
+  const HomeWizardState({
+    this.choices,
+    this.isLoadingChoices = true,
+    this.currentStep = HomeWizardStep.activityTypes,
+    this.selectedActivityTypeIds = const {},
+    this.selectedAgeGroupId,
+    this.selectedRegionId,
+    this.prefetchStatus = HomeWizardPrefetchStatus.idle,
+    this.prefetchedResults = const [],
+    this.filteredResults = const [],
+    this.searchQuery = '',
+    this.errorMessage,
+  });
+
+  final HomeWizardChoices? choices;
+  final bool isLoadingChoices;
+  final HomeWizardStep currentStep;
+  final Set<String> selectedActivityTypeIds;
+  final String? selectedAgeGroupId;
+  final String? selectedRegionId;
+  final HomeWizardPrefetchStatus prefetchStatus;
+  final List<ActivitySearchResultEntity> prefetchedResults;
+  final List<ActivitySearchResultEntity> filteredResults;
+  final String searchQuery;
+  final String? errorMessage;
+
+  bool get isWizardComplete =>
+      selectedActivityTypeIds.isNotEmpty &&
+      selectedAgeGroupId != null &&
+      selectedRegionId != null;
+
+  HomeWizardState copyWith({
+    HomeWizardChoices? choices,
+    bool? isLoadingChoices,
+    HomeWizardStep? currentStep,
+    Set<String>? selectedActivityTypeIds,
+    String? selectedAgeGroupId,
+    String? selectedRegionId,
+    HomeWizardPrefetchStatus? prefetchStatus,
+    List<ActivitySearchResultEntity>? prefetchedResults,
+    List<ActivitySearchResultEntity>? filteredResults,
+    String? searchQuery,
+    String? errorMessage,
+    bool clearError = false,
+    bool clearAgeGroup = false,
+    bool clearRegion = false,
+  }) {
+    return HomeWizardState(
+      choices: choices ?? this.choices,
+      isLoadingChoices: isLoadingChoices ?? this.isLoadingChoices,
+      currentStep: currentStep ?? this.currentStep,
+      selectedActivityTypeIds:
+          selectedActivityTypeIds ?? this.selectedActivityTypeIds,
+      selectedAgeGroupId: clearAgeGroup
+          ? null
+          : (selectedAgeGroupId ?? this.selectedAgeGroupId),
+      selectedRegionId:
+          clearRegion ? null : (selectedRegionId ?? this.selectedRegionId),
+      prefetchStatus: prefetchStatus ?? this.prefetchStatus,
+      prefetchedResults: prefetchedResults ?? this.prefetchedResults,
+      filteredResults: filteredResults ?? this.filteredResults,
+      searchQuery: searchQuery ?? this.searchQuery,
+      errorMessage: clearError ? null : (errorMessage ?? this.errorMessage),
+    );
+  }
+}
+
+class HomeWizardViewModel extends Notifier<HomeWizardState> {
+  late final SearchActivitiesUseCase _searchUseCase;
+
+  @override
+  HomeWizardState build() {
+    _searchUseCase = ref.watch(searchActivitiesUseCaseProvider);
+    Future.microtask(_loadChoices);
+    return const HomeWizardState();
+  }
+
+  Future<void> _loadChoices() async {
+    try {
+      final choices = await HomeWizardChoices.loadFromAsset();
+      state = state.copyWith(
+        choices: choices,
+        isLoadingChoices: false,
+      );
+    } on Exception {
+      state = state.copyWith(
+        isLoadingChoices: false,
+        errorMessage: 'Unable to load activity choices.',
+      );
+    }
+  }
+
+  void toggleActivityType(String activityTypeId) {
+    final updated = Set<String>.from(state.selectedActivityTypeIds);
+    if (updated.contains(activityTypeId)) {
+      updated.remove(activityTypeId);
+    } else {
+      updated.add(activityTypeId);
+    }
+    state = state.copyWith(
+      selectedActivityTypeIds: updated,
+      clearAgeGroup: true,
+      clearRegion: true,
+      prefetchStatus: HomeWizardPrefetchStatus.idle,
+      prefetchedResults: const [],
+      filteredResults: const [],
+    );
+  }
+
+  void confirmActivityTypes() {
+    if (state.selectedActivityTypeIds.isEmpty) {
+      return;
+    }
+    state = state.copyWith(currentStep: HomeWizardStep.ageGroup);
+  }
+
+  Future<void> selectAgeGroup(String ageGroupId) async {
+    state = state.copyWith(
+      selectedAgeGroupId: ageGroupId,
+      clearRegion: true,
+      currentStep: HomeWizardStep.region,
+      prefetchStatus: HomeWizardPrefetchStatus.loading,
+      prefetchedResults: const [],
+      filteredResults: const [],
+      clearError: true,
+    );
+    await _prefetchResults();
+  }
+
+  void selectRegion(String regionId) {
+    state = state.copyWith(
+      selectedRegionId: regionId,
+      currentStep: HomeWizardStep.results,
+    );
+    _applyRegionAndTextFilters();
+  }
+
+  void goToStep(HomeWizardStep step) {
+    state = state.copyWith(currentStep: step);
+    if (step == HomeWizardStep.activityTypes) {
+      state = state.copyWith(
+        clearAgeGroup: true,
+        clearRegion: true,
+        prefetchStatus: HomeWizardPrefetchStatus.idle,
+        prefetchedResults: const [],
+        filteredResults: const [],
+      );
+    } else if (step == HomeWizardStep.ageGroup) {
+      state = state.copyWith(
+        clearRegion: true,
+        filteredResults: const [],
+      );
+    }
+  }
+
+  void updateSearchQuery(String query) {
+    state = state.copyWith(searchQuery: query);
+    _applyRegionAndTextFilters();
+  }
+
+  Future<void> retryPrefetch() async {
+    state = state.copyWith(
+      prefetchStatus: HomeWizardPrefetchStatus.loading,
+      clearError: true,
+    );
+    await _prefetchResults();
+  }
+
+  Future<void> _prefetchResults() async {
+    final choices = state.choices;
+    final ageGroupId = state.selectedAgeGroupId;
+    if (choices == null || ageGroupId == null) {
+      return;
+    }
+
+    final ageGroup = choices.ageGroups.firstWhere(
+      (group) => group.id == ageGroupId,
+    );
+    final categoryIds = choices.activityTypes
+        .where((type) => state.selectedActivityTypeIds.contains(type.id))
+        .map((type) => type.categoryId)
+        .toList();
+
+    final filters = SearchFilters(
+      age: ageGroup.searchAge,
+      categoryIds: categoryIds,
+      limit: 200,
+    );
+
+    final result = await _searchUseCase.execute(filters);
+    switch (result) {
+      case Ok(value: final data):
+        state = state.copyWith(
+          prefetchStatus: HomeWizardPrefetchStatus.ready,
+          prefetchedResults: data.items,
+        );
+        if (state.selectedRegionId != null) {
+          _applyRegionAndTextFilters();
+        }
+      case Error():
+        state = state.copyWith(
+          prefetchStatus: HomeWizardPrefetchStatus.error,
+          errorMessage: 'Unable to load activities. Pull to retry.',
+        );
+    }
+  }
+
+  void _applyRegionAndTextFilters() {
+    final choices = state.choices;
+    final regionId = state.selectedRegionId;
+    if (choices == null || regionId == null) {
+      return;
+    }
+
+    final region = choices.regions.firstWhere((item) => item.id == regionId);
+    final query = state.searchQuery.trim().toLowerCase();
+    final filtered = state.prefetchedResults.where((result) {
+      final matchesRegion =
+          result.location.regionAreaId == region.areaId;
+      if (!matchesRegion) {
+        return false;
+      }
+      if (query.isEmpty) {
+        return true;
+      }
+      final haystack = [
+        result.activity.name,
+        result.activity.description ?? '',
+        result.organization.name,
+      ].join(' ').toLowerCase();
+      return haystack.contains(query);
+    }).toList();
+
+    state = state.copyWith(filteredResults: filtered);
+  }
+}
+
+final homeWizardViewModelProvider =
+    NotifierProvider<HomeWizardViewModel, HomeWizardState>(
+  HomeWizardViewModel.new,
+);

--- a/apps/siutindei_app/lib/features/home_wizard/models/home_wizard_choices.dart
+++ b/apps/siutindei_app/lib/features/home_wizard/models/home_wizard_choices.dart
@@ -1,0 +1,131 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
+
+/// Localized label map (en + zh-HK).
+class WizardLabels {
+  const WizardLabels({required this.en, required this.zhHk});
+
+  factory WizardLabels.fromJson(Map<String, dynamic> json) {
+    return WizardLabels(
+      en: json['en'] as String? ?? '',
+      zhHk: json['zh-HK'] as String? ?? '',
+    );
+  }
+
+  final String en;
+  final String zhHk;
+
+  String forLocale(String locale) {
+    if (locale == 'zh-HK' && zhHk.isNotEmpty) {
+      return zhHk;
+    }
+    return en;
+  }
+}
+
+class WizardActivityTypeOption {
+  const WizardActivityTypeOption({
+    required this.id,
+    required this.categoryId,
+    required this.labels,
+  });
+
+  factory WizardActivityTypeOption.fromJson(Map<String, dynamic> json) {
+    return WizardActivityTypeOption(
+      id: json['id'] as String,
+      categoryId: json['categoryId'] as String,
+      labels: WizardLabels.fromJson(json['labels'] as Map<String, dynamic>),
+    );
+  }
+
+  final String id;
+  final String categoryId;
+  final WizardLabels labels;
+}
+
+class WizardAgeGroupOption {
+  const WizardAgeGroupOption({
+    required this.id,
+    required this.searchAge,
+    required this.labels,
+  });
+
+  factory WizardAgeGroupOption.fromJson(Map<String, dynamic> json) {
+    return WizardAgeGroupOption(
+      id: json['id'] as String,
+      searchAge: json['searchAge'] as int,
+      labels: WizardLabels.fromJson(json['labels'] as Map<String, dynamic>),
+    );
+  }
+
+  final String id;
+  final int searchAge;
+  final WizardLabels labels;
+}
+
+class WizardRegionOption {
+  const WizardRegionOption({
+    required this.id,
+    required this.areaId,
+    required this.labels,
+  });
+
+  factory WizardRegionOption.fromJson(Map<String, dynamic> json) {
+    return WizardRegionOption(
+      id: json['id'] as String,
+      areaId: json['areaId'] as String,
+      labels: WizardLabels.fromJson(json['labels'] as Map<String, dynamic>),
+    );
+  }
+
+  final String id;
+  final String areaId;
+  final WizardLabels labels;
+}
+
+class HomeWizardChoices {
+  const HomeWizardChoices({
+    required this.activityTypes,
+    required this.ageGroups,
+    required this.regions,
+  });
+
+  factory HomeWizardChoices.fromJson(Map<String, dynamic> json) {
+    final activityTypesJson = json['activityTypes'] as List<dynamic>? ?? [];
+    final ageGroupsJson = json['ageGroups'] as List<dynamic>? ?? [];
+    final regionsJson = json['regions'] as List<dynamic>? ?? [];
+    return HomeWizardChoices(
+      activityTypes: activityTypesJson
+          .map(
+            (item) => WizardActivityTypeOption.fromJson(
+              item as Map<String, dynamic>,
+            ),
+          )
+          .toList(),
+      ageGroups: ageGroupsJson
+          .map(
+            (item) =>
+                WizardAgeGroupOption.fromJson(item as Map<String, dynamic>),
+          )
+          .toList(),
+      regions: regionsJson
+          .map(
+            (item) => WizardRegionOption.fromJson(item as Map<String, dynamic>),
+          )
+          .toList(),
+    );
+  }
+
+  final List<WizardActivityTypeOption> activityTypes;
+  final List<WizardAgeGroupOption> ageGroups;
+  final List<WizardRegionOption> regions;
+
+  static Future<HomeWizardChoices> loadFromAsset() async {
+    final raw = await rootBundle.loadString(
+      'assets/home_wizard/home_wizard_choices.json',
+    );
+    final json = jsonDecode(raw) as Map<String, dynamic>;
+    return HomeWizardChoices.fromJson(json);
+  }
+}

--- a/apps/siutindei_app/lib/features/home_wizard/screens/home_wizard_screen.dart
+++ b/apps/siutindei_app/lib/features/home_wizard/screens/home_wizard_screen.dart
@@ -1,0 +1,381 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../config/tokens/tokens.dart';
+import '../../../domain/entities/entities.dart';
+import '../../activity_detail/screens/activity_detail_screen.dart';
+import '../../organization/screens/organization_screen.dart';
+import '../../search/widgets/activity_card.dart';
+import '../home_wizard_viewmodel.dart';
+import '../models/home_wizard_choices.dart';
+
+/// Home screen with sequential wizard, summary chips, and search results.
+class HomeWizardScreen extends ConsumerStatefulWidget {
+  const HomeWizardScreen({super.key});
+
+  @override
+  ConsumerState<HomeWizardScreen> createState() => _HomeWizardScreenState();
+}
+
+class _HomeWizardScreenState extends ConsumerState<HomeWizardScreen> {
+  final _searchController = TextEditingController();
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final wizardState = ref.watch(homeWizardViewModelProvider);
+    final spacing = ref.watch(semanticTokensProvider.select((s) => s.spacing));
+    final textStyles = ref.watch(semanticTokensProvider.select((s) => s.text));
+
+    if (wizardState.isLoadingChoices) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    if (wizardState.choices == null) {
+      return Scaffold(
+        body: Center(
+          child: Text(
+            wizardState.errorMessage ?? 'Unable to load choices.',
+            style: textStyles.bodyMedium,
+          ),
+        ),
+      );
+    }
+
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding: EdgeInsets.fromLTRB(
+                spacing.md,
+                spacing.md,
+                spacing.md,
+                spacing.sm,
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Siu Tin Dei',
+                    style: textStyles.headlineMedium,
+                  ),
+                  SizedBox(height: spacing.sm),
+                  _WizardSummaryBar(
+                    choices: wizardState.choices!,
+                    state: wizardState,
+                  ),
+                ],
+              ),
+            ),
+            if (wizardState.currentStep != HomeWizardStep.results)
+              Expanded(
+                child: _WizardStepContent(
+                  choices: wizardState.choices!,
+                  state: wizardState,
+                ),
+              )
+            else ...[
+              Padding(
+                padding: EdgeInsets.symmetric(horizontal: spacing.md),
+                child: TextField(
+                  controller: _searchController,
+                  decoration: const InputDecoration(
+                    hintText: 'Search activities, organizations...',
+                    prefixIcon: Icon(Icons.search),
+                  ),
+                  onChanged: (value) {
+                    ref
+                        .read(homeWizardViewModelProvider.notifier)
+                        .updateSearchQuery(value);
+                  },
+                ),
+              ),
+              SizedBox(height: spacing.sm),
+              Expanded(
+                child: _WizardResultsList(state: wizardState),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _WizardSummaryBar extends ConsumerWidget {
+  const _WizardSummaryBar({
+    required this.choices,
+    required this.state,
+  });
+
+  final HomeWizardChoices choices;
+  final HomeWizardState state;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final spacing = ref.watch(semanticTokensProvider.select((s) => s.spacing));
+    final notifier = ref.read(homeWizardViewModelProvider.notifier);
+
+    final activityLabel = _activitySummaryLabel();
+    final ageLabel = _ageSummaryLabel();
+    final regionLabel = _regionSummaryLabel();
+
+    return Wrap(
+      spacing: spacing.sm,
+      runSpacing: spacing.sm,
+      children: [
+        if (activityLabel != null)
+          ActionChip(
+            label: Text(activityLabel),
+            onPressed: () => notifier.goToStep(HomeWizardStep.activityTypes),
+          ),
+        if (ageLabel != null)
+          ActionChip(
+            label: Text(ageLabel),
+            onPressed: () => notifier.goToStep(HomeWizardStep.ageGroup),
+          ),
+        if (regionLabel != null)
+          ActionChip(
+            label: Text(regionLabel),
+            onPressed: () => notifier.goToStep(HomeWizardStep.region),
+          ),
+      ],
+    );
+  }
+
+  String? _activitySummaryLabel() {
+    if (state.selectedActivityTypeIds.isEmpty) {
+      return null;
+    }
+    final labels = choices.activityTypes
+        .where((type) => state.selectedActivityTypeIds.contains(type.id))
+        .map((type) => type.labels.en)
+        .toList();
+    return labels.join(', ');
+  }
+
+  String? _ageSummaryLabel() {
+    final ageGroupId = state.selectedAgeGroupId;
+    if (ageGroupId == null) {
+      return null;
+    }
+    return choices.ageGroups
+        .firstWhere((group) => group.id == ageGroupId)
+        .labels
+        .en;
+  }
+
+  String? _regionSummaryLabel() {
+    final regionId = state.selectedRegionId;
+    if (regionId == null) {
+      return null;
+    }
+    return choices.regions
+        .firstWhere((region) => region.id == regionId)
+        .labels
+        .en;
+  }
+}
+
+class _WizardStepContent extends ConsumerWidget {
+  const _WizardStepContent({
+    required this.choices,
+    required this.state,
+  });
+
+  final HomeWizardChoices choices;
+  final HomeWizardState state;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final spacing = ref.watch(semanticTokensProvider.select((s) => s.spacing));
+    final textStyles = ref.watch(semanticTokensProvider.select((s) => s.text));
+    final notifier = ref.read(homeWizardViewModelProvider.notifier);
+
+    switch (state.currentStep) {
+      case HomeWizardStep.activityTypes:
+        return ListView(
+          padding: EdgeInsets.all(spacing.md),
+          children: [
+            Text(
+              'What activities are you looking for?',
+              style: textStyles.titleMedium,
+            ),
+            SizedBox(height: spacing.md),
+            for (final option in choices.activityTypes)
+              _WizardOptionTile(
+                label: option.labels.en,
+                selected: state.selectedActivityTypeIds.contains(option.id),
+                onTap: () => notifier.toggleActivityType(option.id),
+              ),
+            SizedBox(height: spacing.md),
+            FilledButton(
+              onPressed: state.selectedActivityTypeIds.isEmpty
+                  ? null
+                  : notifier.confirmActivityTypes,
+              child: const Text('Continue'),
+            ),
+          ],
+        );
+      case HomeWizardStep.ageGroup:
+        return ListView(
+          padding: EdgeInsets.all(spacing.md),
+          children: [
+            Text(
+              'How old is your child?',
+              style: textStyles.titleMedium,
+            ),
+            SizedBox(height: spacing.md),
+            for (final option in choices.ageGroups)
+              _WizardOptionTile(
+                label: option.labels.en,
+                selected: state.selectedAgeGroupId == option.id,
+                onTap: () => notifier.selectAgeGroup(option.id),
+              ),
+          ],
+        );
+      case HomeWizardStep.region:
+        return ListView(
+          padding: EdgeInsets.all(spacing.md),
+          children: [
+            Text(
+              'Which area is near you?',
+              style: textStyles.titleMedium,
+            ),
+            if (state.prefetchStatus == HomeWizardPrefetchStatus.loading)
+              Padding(
+                padding: EdgeInsets.only(top: spacing.md),
+                child: const LinearProgressIndicator(),
+              ),
+            SizedBox(height: spacing.md),
+            for (final option in choices.regions)
+              _WizardOptionTile(
+                label: option.labels.en,
+                selected: state.selectedRegionId == option.id,
+                onTap: () => notifier.selectRegion(option.id),
+              ),
+          ],
+        );
+      case HomeWizardStep.results:
+        return const SizedBox.shrink();
+    }
+  }
+}
+
+class _WizardOptionTile extends StatelessWidget {
+  const _WizardOptionTile({
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: 8),
+      child: ListTile(
+        title: Text(label),
+        trailing: selected ? const Icon(Icons.check_circle) : null,
+        onTap: onTap,
+      ),
+    );
+  }
+}
+
+class _WizardResultsList extends ConsumerWidget {
+  const _WizardResultsList({required this.state});
+
+  final HomeWizardState state;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = ref.watch(semanticTokensProvider.select((s) => s.color));
+    final spacing = ref.watch(semanticTokensProvider.select((s) => s.spacing));
+    final textStyles = ref.watch(semanticTokensProvider.select((s) => s.text));
+
+    if (state.prefetchStatus == HomeWizardPrefetchStatus.loading) {
+      return Center(
+        child: CircularProgressIndicator(color: colors.primary),
+      );
+    }
+
+    if (state.prefetchStatus == HomeWizardPrefetchStatus.error) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              state.errorMessage ?? 'Something went wrong',
+              style: textStyles.bodyMedium,
+            ),
+            SizedBox(height: spacing.md),
+            ElevatedButton(
+              onPressed: () {
+                ref.read(homeWizardViewModelProvider.notifier).retryPrefetch();
+              },
+              child: const Text('Try again'),
+            ),
+          ],
+        ),
+      );
+    }
+
+    if (state.filteredResults.isEmpty) {
+      return Center(
+        child: Text(
+          'No activities found. Try changing your choices.',
+          style: textStyles.bodyMedium,
+          textAlign: TextAlign.center,
+        ),
+      );
+    }
+
+    return ListView.builder(
+      padding: EdgeInsets.only(top: spacing.sm),
+      itemCount: state.filteredResults.length,
+      itemBuilder: (context, index) {
+        final result = state.filteredResults[index];
+        return ActivityCard(
+          key: ValueKey(result.id),
+          result: result,
+          onTap: () => _openDetail(context, result),
+          onOrganizationTap: () => _openOrganization(context, result),
+        );
+      },
+    );
+  }
+
+  void _openDetail(BuildContext context, ActivitySearchResultEntity result) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => ActivityDetailScreen(result: result),
+      ),
+    );
+  }
+
+  void _openOrganization(
+    BuildContext context,
+    ActivitySearchResultEntity result,
+  ) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => OrganizationScreen(organization: result.organization),
+      ),
+    );
+  }
+}

--- a/apps/siutindei_app/lib/models/activity_models.dart
+++ b/apps/siutindei_app/lib/models/activity_models.dart
@@ -2,6 +2,7 @@ class ActivitySearchFilters {
   ActivitySearchFilters({
     this.age,
     this.areaId,
+    this.categoryIds = const [],
     this.pricingType,
     this.priceMin,
     this.priceMax,
@@ -20,6 +21,7 @@ class ActivitySearchFilters {
 
   final int? age;
   final String? areaId;
+  final List<String> categoryIds;
   final String? pricingType;
   final double? priceMin;
   final double? priceMax;
@@ -39,6 +41,7 @@ class ActivitySearchFilters {
   ActivitySearchFilters copyWith({
     int? age,
     String? areaId,
+    List<String>? categoryIds,
     String? pricingType,
     double? priceMin,
     double? priceMax,
@@ -71,6 +74,7 @@ class ActivitySearchFilters {
     return ActivitySearchFilters(
       age: clearAge ? null : (age ?? this.age),
       areaId: clearAreaId ? null : (areaId ?? this.areaId),
+      categoryIds: categoryIds ?? this.categoryIds,
       pricingType: clearPricingType ? null : (pricingType ?? this.pricingType),
       priceMin: clearPriceMin ? null : (priceMin ?? this.priceMin),
       priceMax: clearPriceMax ? null : (priceMax ?? this.priceMax),
@@ -137,6 +141,9 @@ class ActivitySearchFilters {
 
     setParam('age', age);
     setParam('area_id', areaId);
+    if (categoryIds.isNotEmpty) {
+      params['category_id'] = categoryIds.join(',');
+    }
     setParam('pricing_type', pricingType);
     setParam('price_min', priceMin);
     setParam('price_max', priceMax);
@@ -206,13 +213,21 @@ class ActivitySearchResult {
 }
 
 class Activity {
-  Activity({required this.id, required this.name, this.description, this.ageMin, this.ageMax});
+  Activity({
+    required this.id,
+    required this.name,
+    this.description,
+    this.ageMin,
+    this.ageMax,
+    this.categoryId,
+  });
 
   final String id;
   final String name;
   final String? description;
   final int? ageMin;
   final int? ageMax;
+  final String? categoryId;
 
   factory Activity.fromJson(Map<String, dynamic> json) {
     return Activity(
@@ -221,6 +236,7 @@ class Activity {
       description: json['description'] as String?,
       ageMin: json['age_min'] as int?,
       ageMax: json['age_max'] as int?,
+      categoryId: json['category_id'] as String?,
     );
   }
 }
@@ -261,6 +277,7 @@ class Location {
   Location({
     required this.id,
     required this.areaId,
+    this.regionAreaId,
     this.address,
     this.lat,
     this.lng,
@@ -268,6 +285,7 @@ class Location {
 
   final String id;
   final String areaId;
+  final String? regionAreaId;
   final String? address;
   final double? lat;
   final double? lng;
@@ -276,6 +294,7 @@ class Location {
     return Location(
       id: json['id'] as String,
       areaId: json['area_id'] as String,
+      regionAreaId: json['region_area_id'] as String?,
       address: json['address'] as String?,
       lat: (json['lat'] as num?)?.toDouble(),
       lng: (json['lng'] as num?)?.toDouble(),

--- a/apps/siutindei_app/pubspec.yaml
+++ b/apps/siutindei_app/pubspec.yaml
@@ -23,3 +23,5 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+  assets:
+    - assets/home_wizard/home_wizard_choices.json

--- a/apps/siutindei_app/test/home_wizard_choices_test.dart
+++ b/apps/siutindei_app/test/home_wizard_choices_test.dart
@@ -1,0 +1,45 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:siutindei_app/features/home_wizard/models/home_wizard_choices.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('parses shared home wizard choices json', () {
+    const raw = '''
+{
+  "version": 1,
+  "activityTypes": [
+    {
+      "id": "workshop",
+      "categoryId": "c1111111-1111-1111-1111-111111111101",
+      "labels": { "en": "Workshop", "zh-HK": "工作坊" }
+    }
+  ],
+  "ageGroups": [
+    {
+      "id": "1-3",
+      "searchAge": 2,
+      "labels": { "en": "1–3 years", "zh-HK": "1–3歲" }
+    }
+  ],
+  "regions": [
+    {
+      "id": "hong_kong_island",
+      "areaId": "a1111111-1111-1111-1111-111111111101",
+      "labels": { "en": "Hong Kong Island", "zh-HK": "香港島" }
+    }
+  ]
+}
+''';
+
+    final choices = HomeWizardChoices.fromJson(
+      jsonDecode(raw) as Map<String, dynamic>,
+    );
+
+    expect(choices.activityTypes, hasLength(1));
+    expect(choices.ageGroups.first.searchAge, 2);
+    expect(choices.regions.first.areaId, isNotEmpty);
+  });
+}

--- a/backend/db/alembic/versions/0028_hk_regions_wizard.py
+++ b/backend/db/alembic/versions/0028_hk_regions_wizard.py
@@ -61,6 +61,10 @@ NEW_TERRITORIES_DISTRICTS = (
 )
 ISLANDS_DISTRICTS = ("Islands",)
 
+# District "Islands" already exists under HK; region row uses a temporary
+# distinct name until districts are reparented, then renames to "Islands".
+ISLANDS_REGION_STAGING_NAME = "Outlying Islands"
+
 GEO_AREAS = sa.table(
     "geographic_areas",
     sa.column("id", postgresql.UUID(as_uuid=True)),
@@ -215,7 +219,7 @@ def upgrade() -> None:
         connection,
         hk_country_id,
         ISLANDS_ID,
-        "Islands",
+        ISLANDS_REGION_STAGING_NAME,
         "hk_islands",
         "Islands",
         "離島",
@@ -231,6 +235,11 @@ def upgrade() -> None:
         NEW_TERRITORIES_DISTRICTS,
     )
     _reparent_districts(connection, hk_country_id, ISLANDS_ID, ISLANDS_DISTRICTS)
+    connection.execute(
+        sa.update(GEO_AREAS)
+        .where(GEO_AREAS.c.id == ISLANDS_ID)
+        .values(name="Islands")
+    )
 
     _insert_category(
         connection,
@@ -304,5 +313,10 @@ def downgrade() -> None:
             )
         )
         .values(parent_id=hk_country_id)
+    )
+    connection.execute(
+        sa.update(GEO_AREAS)
+        .where(GEO_AREAS.c.id == ISLANDS_ID)
+        .values(name=ISLANDS_REGION_STAGING_NAME)
     )
     connection.execute(sa.delete(GEO_AREAS).where(GEO_AREAS.c.id.in_(region_ids)))

--- a/backend/db/alembic/versions/0028_hk_regions_wizard.py
+++ b/backend/db/alembic/versions/0028_hk_regions_wizard.py
@@ -1,0 +1,261 @@
+"""Add HK macro regions and wizard activity categories.
+
+Inserts Hong Kong Island, Kowloon, New Territories, and Islands as
+level=region nodes under Hong Kong, reparents districts beneath them,
+and seeds workshop/class/outdoor/indoor categories for the home wizard.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+from typing import Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0028_hk_regions_wizard"
+down_revision: Union[str, None] = "0027_add_feedback_tables"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+HK_ISLAND_ID = "a1111111-1111-1111-1111-111111111101"
+KOWLOON_ID = "a1111111-1111-1111-1111-111111111102"
+NEW_TERRITORIES_ID = "a1111111-1111-1111-1111-111111111103"
+ISLANDS_ID = "a1111111-1111-1111-1111-111111111104"
+
+WORKSHOP_CATEGORY_ID = "c1111111-1111-1111-1111-111111111101"
+CLASS_CATEGORY_ID = "c1111111-1111-1111-1111-111111111102"
+OUTDOOR_CATEGORY_ID = "c1111111-1111-1111-1111-111111111103"
+INDOOR_CATEGORY_ID = "c1111111-1111-1111-1111-111111111104"
+
+HK_ISLAND_DISTRICTS = (
+    "Central and Western",
+    "Eastern",
+    "Southern",
+    "Wan Chai",
+)
+KOWLOON_DISTRICTS = (
+    "Kowloon City",
+    "Kwun Tong",
+    "Sham Shui Po",
+    "Wong Tai Sin",
+    "Yau Tsim Mong",
+)
+NEW_TERRITORIES_DISTRICTS = (
+    "Kwai Tsing",
+    "North",
+    "Sai Kung",
+    "Sha Tin",
+    "Tai Po",
+    "Tsuen Wan",
+    "Tuen Mun",
+    "Yuen Long",
+)
+ISLANDS_DISTRICTS = ("Islands",)
+
+
+def _insert_region(
+    region_id: str,
+    name: str,
+    code: str,
+    name_en: str,
+    name_zh: str,
+    display_order: int,
+) -> None:
+    op.execute(
+        sa.text(
+            f"""
+            INSERT INTO geographic_areas (
+                id, parent_id, name, name_translations, level, code,
+                active, display_order
+            )
+            SELECT '{region_id}'::uuid, hk.id, :name,
+                   jsonb_build_object('en', :name_en, 'zh-HK', :name_zh),
+                   'region', :code, true, :display_order
+            FROM geographic_areas hk
+            WHERE hk.code = 'HK' AND hk.level = 'country'
+              AND NOT EXISTS (
+                  SELECT 1 FROM geographic_areas
+                  WHERE id = '{region_id}'::uuid
+              )
+            """
+        ).bindparams(
+            name=name,
+            name_en=name_en,
+            name_zh=name_zh,
+            code=code,
+            display_order=display_order,
+        )
+    )
+
+
+def _reparent_districts(region_id: str, district_names: tuple[str, ...]) -> None:
+    for district_name in district_names:
+        op.execute(
+            sa.text(
+                f"""
+                UPDATE geographic_areas
+                SET parent_id = '{region_id}'::uuid
+                WHERE level = 'district'
+                  AND name = :district_name
+                  AND parent_id IN (
+                      SELECT id FROM geographic_areas
+                      WHERE code = 'HK' AND level = 'country'
+                  )
+                """
+            ).bindparams(district_name=district_name)
+        )
+
+
+def upgrade() -> None:
+    """Insert HK regions, reparent districts, and seed wizard categories."""
+    _insert_region(
+        HK_ISLAND_ID,
+        "Hong Kong Island",
+        "hk_island",
+        "Hong Kong Island",
+        "香港島",
+        1,
+    )
+    _insert_region(
+        KOWLOON_ID,
+        "Kowloon",
+        "hk_kowloon",
+        "Kowloon",
+        "九龍",
+        2,
+    )
+    _insert_region(
+        NEW_TERRITORIES_ID,
+        "New Territories",
+        "hk_new_territories",
+        "New Territories",
+        "新界",
+        3,
+    )
+    _insert_region(
+        ISLANDS_ID,
+        "Islands",
+        "hk_islands",
+        "Islands",
+        "離島",
+        4,
+    )
+
+    _reparent_districts(HK_ISLAND_ID, HK_ISLAND_DISTRICTS)
+    _reparent_districts(KOWLOON_ID, KOWLOON_DISTRICTS)
+    _reparent_districts(NEW_TERRITORIES_ID, NEW_TERRITORIES_DISTRICTS)
+    _reparent_districts(ISLANDS_ID, ISLANDS_DISTRICTS)
+
+    for category_id, name, translations, display_order in (
+        (
+            WORKSHOP_CATEGORY_ID,
+            "Workshop",
+            '{"en": "Workshop", "zh-HK": "工作坊"}',
+            2,
+        ),
+        (
+            CLASS_CATEGORY_ID,
+            "Class",
+            '{"en": "Class", "zh-HK": "課程"}',
+            3,
+        ),
+        (
+            OUTDOOR_CATEGORY_ID,
+            "Outdoor activity",
+            '{"en": "Outdoor activity", "zh-HK": "戶外活動"}',
+            4,
+        ),
+        (
+            INDOOR_CATEGORY_ID,
+            "Indoor fun",
+            '{"en": "Indoor fun", "zh-HK": "室內玩樂"}',
+            5,
+        ),
+    ):
+        op.execute(
+            f"""
+            INSERT INTO activity_categories (
+                id, parent_id, name, name_translations, display_order
+            )
+            SELECT '{category_id}'::uuid, NULL, '{name}',
+                   '{translations}'::jsonb, {display_order}
+            WHERE NOT EXISTS (
+                SELECT 1 FROM activity_categories
+                WHERE id = '{category_id}'::uuid
+            )
+            """
+        )
+
+    op.execute(
+        sa.text(
+            f"""
+            UPDATE activities
+            SET category_id = '{WORKSHOP_CATEGORY_ID}'::uuid
+            WHERE id = 'dddddddd-dddd-dddd-dddd-dddddddddddd'
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            f"""
+            UPDATE activities
+            SET category_id = '{CLASS_CATEGORY_ID}'::uuid
+            WHERE id = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    """Restore flat HK districts and remove wizard categories."""
+    op.execute(
+        """
+        UPDATE activities
+        SET category_id = '99999999-9999-9999-9999-999999999999'
+        WHERE id IN (
+            'dddddddd-dddd-dddd-dddd-dddddddddddd',
+            'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'
+        )
+        """
+    )
+    op.execute(
+        f"""
+        DELETE FROM activity_categories
+        WHERE id IN (
+            '{WORKSHOP_CATEGORY_ID}'::uuid,
+            '{CLASS_CATEGORY_ID}'::uuid,
+            '{OUTDOOR_CATEGORY_ID}'::uuid,
+            '{INDOOR_CATEGORY_ID}'::uuid
+        )
+        """
+    )
+
+    op.execute(
+        f"""
+        UPDATE geographic_areas AS district
+        SET parent_id = hk.id
+        FROM geographic_areas hk
+        WHERE hk.code = 'HK'
+          AND hk.level = 'country'
+          AND district.level = 'district'
+          AND district.parent_id IN (
+              '{HK_ISLAND_ID}'::uuid,
+              '{KOWLOON_ID}'::uuid,
+              '{NEW_TERRITORIES_ID}'::uuid,
+              '{ISLANDS_ID}'::uuid
+          )
+        """
+    )
+    op.execute(
+        f"""
+        DELETE FROM geographic_areas
+        WHERE id IN (
+            '{HK_ISLAND_ID}'::uuid,
+            '{KOWLOON_ID}'::uuid,
+            '{NEW_TERRITORIES_ID}'::uuid,
+            '{ISLANDS_ID}'::uuid
+        )
+        """
+    )

--- a/backend/db/alembic/versions/0028_hk_regions_wizard.py
+++ b/backend/db/alembic/versions/0028_hk_regions_wizard.py
@@ -12,7 +12,6 @@ from typing import Union
 
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
 
 revision: str = "0028_hk_regions_wizard"
 down_revision: Union[str, None] = "0027_add_feedback_tables"

--- a/backend/db/alembic/versions/0028_hk_regions_wizard.py
+++ b/backend/db/alembic/versions/0028_hk_regions_wizard.py
@@ -236,9 +236,7 @@ def upgrade() -> None:
     )
     _reparent_districts(connection, hk_country_id, ISLANDS_ID, ISLANDS_DISTRICTS)
     connection.execute(
-        sa.update(GEO_AREAS)
-        .where(GEO_AREAS.c.id == ISLANDS_ID)
-        .values(name="Islands")
+        sa.update(GEO_AREAS).where(GEO_AREAS.c.id == ISLANDS_ID).values(name="Islands")
     )
 
     _insert_category(

--- a/backend/db/alembic/versions/0028_hk_regions_wizard.py
+++ b/backend/db/alembic/versions/0028_hk_regions_wizard.py
@@ -7,26 +7,34 @@ and seeds workshop/class/outdoor/indoor categories for the home wizard.
 
 from __future__ import annotations
 
+import uuid
 from typing import Sequence
 from typing import Union
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 revision: str = "0028_hk_regions_wizard"
 down_revision: Union[str, None] = "0027_add_feedback_tables"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
-HK_ISLAND_ID = "a1111111-1111-1111-1111-111111111101"
-KOWLOON_ID = "a1111111-1111-1111-1111-111111111102"
-NEW_TERRITORIES_ID = "a1111111-1111-1111-1111-111111111103"
-ISLANDS_ID = "a1111111-1111-1111-1111-111111111104"
+HK_ISLAND_ID = uuid.UUID("a1111111-1111-1111-1111-111111111101")
+KOWLOON_ID = uuid.UUID("a1111111-1111-1111-1111-111111111102")
+NEW_TERRITORIES_ID = uuid.UUID("a1111111-1111-1111-1111-111111111103")
+ISLANDS_ID = uuid.UUID("a1111111-1111-1111-1111-111111111104")
 
-WORKSHOP_CATEGORY_ID = "c1111111-1111-1111-1111-111111111101"
-CLASS_CATEGORY_ID = "c1111111-1111-1111-1111-111111111102"
-OUTDOOR_CATEGORY_ID = "c1111111-1111-1111-1111-111111111103"
-INDOOR_CATEGORY_ID = "c1111111-1111-1111-1111-111111111104"
+WORKSHOP_CATEGORY_ID = uuid.UUID("c1111111-1111-1111-1111-111111111101")
+CLASS_CATEGORY_ID = uuid.UUID("c1111111-1111-1111-1111-111111111102")
+OUTDOOR_CATEGORY_ID = uuid.UUID("c1111111-1111-1111-1111-111111111103")
+INDOOR_CATEGORY_ID = uuid.UUID("c1111111-1111-1111-1111-111111111104")
+
+SPORT_CATEGORY_ID = uuid.UUID("99999999-9999-9999-9999-999999999999")
+
+PAINTING_ACTIVITY_ID = uuid.UUID("dddddddd-dddd-dddd-dddd-dddddddddddd")
+DANCE_ACTIVITY_ID = uuid.UUID("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee")
 
 HK_ISLAND_DISTRICTS = (
     "Central and Western",
@@ -53,63 +61,129 @@ NEW_TERRITORIES_DISTRICTS = (
 )
 ISLANDS_DISTRICTS = ("Islands",)
 
+GEO_AREAS = sa.table(
+    "geographic_areas",
+    sa.column("id", postgresql.UUID(as_uuid=True)),
+    sa.column("parent_id", postgresql.UUID(as_uuid=True)),
+    sa.column("name", sa.Text()),
+    sa.column("name_translations", postgresql.JSONB()),
+    sa.column("level", sa.Text()),
+    sa.column("code", sa.Text()),
+    sa.column("active", sa.Boolean()),
+    sa.column("display_order", sa.Integer()),
+)
+
+ACTIVITY_CATEGORIES = sa.table(
+    "activity_categories",
+    sa.column("id", postgresql.UUID(as_uuid=True)),
+    sa.column("parent_id", postgresql.UUID(as_uuid=True)),
+    sa.column("name", sa.Text()),
+    sa.column("name_translations", postgresql.JSONB()),
+    sa.column("display_order", sa.Integer()),
+)
+
+ACTIVITIES = sa.table(
+    "activities",
+    sa.column("id", postgresql.UUID(as_uuid=True)),
+    sa.column("category_id", postgresql.UUID(as_uuid=True)),
+)
+
+
+def _hk_country_id(connection: sa.Connection) -> uuid.UUID:
+    """Return the Hong Kong country geographic_areas row id."""
+
+    row = connection.execute(
+        sa.select(GEO_AREAS.c.id).where(
+            sa.and_(GEO_AREAS.c.code == "HK", GEO_AREAS.c.level == "country")
+        )
+    ).first()
+    if row is None:
+        msg = "Hong Kong country row not found in geographic_areas"
+        raise RuntimeError(msg)
+    return row[0]
+
+
+def _region_exists(connection: sa.Connection, region_id: uuid.UUID) -> bool:
+    row = connection.execute(
+        sa.select(sa.literal(1)).where(GEO_AREAS.c.id == region_id)
+    ).first()
+    return row is not None
+
 
 def _insert_region(
-    region_id: str,
+    connection: sa.Connection,
+    hk_country_id: uuid.UUID,
+    region_id: uuid.UUID,
     name: str,
     code: str,
     name_en: str,
     name_zh: str,
     display_order: int,
 ) -> None:
-    op.execute(
-        sa.text(
-            f"""
-            INSERT INTO geographic_areas (
-                id, parent_id, name, name_translations, level, code,
-                active, display_order
-            )
-            SELECT '{region_id}'::uuid, hk.id, :name,
-                   jsonb_build_object('en', :name_en, 'zh-HK', :name_zh),
-                   'region', :code, true, :display_order
-            FROM geographic_areas hk
-            WHERE hk.code = 'HK' AND hk.level = 'country'
-              AND NOT EXISTS (
-                  SELECT 1 FROM geographic_areas
-                  WHERE id = '{region_id}'::uuid
-              )
-            """
-        ).bindparams(
+    if _region_exists(connection, region_id):
+        return
+    connection.execute(
+        sa.insert(GEO_AREAS).values(
+            id=region_id,
+            parent_id=hk_country_id,
             name=name,
-            name_en=name_en,
-            name_zh=name_zh,
+            name_translations={"en": name_en, "zh-HK": name_zh},
+            level="region",
             code=code,
+            active=True,
             display_order=display_order,
         )
     )
 
 
-def _reparent_districts(region_id: str, district_names: tuple[str, ...]) -> None:
-    for district_name in district_names:
-        op.execute(
-            sa.text(
-                f"""
-                UPDATE geographic_areas
-                SET parent_id = '{region_id}'::uuid
-                WHERE level = 'district'
-                  AND name = :district_name
-                  AND parent_id IN (
-                      SELECT id FROM geographic_areas
-                      WHERE code = 'HK' AND level = 'country'
-                  )
-                """
-            ).bindparams(district_name=district_name)
+def _reparent_districts(
+    connection: sa.Connection,
+    hk_country_id: uuid.UUID,
+    region_id: uuid.UUID,
+    district_names: tuple[str, ...],
+) -> None:
+    connection.execute(
+        sa.update(GEO_AREAS)
+        .where(
+            sa.and_(
+                GEO_AREAS.c.level == "district",
+                GEO_AREAS.c.name.in_(district_names),
+                GEO_AREAS.c.parent_id == hk_country_id,
+            )
         )
+        .values(parent_id=region_id)
+    )
+
+
+def _insert_category(
+    connection: sa.Connection,
+    category_id: uuid.UUID,
+    name: str,
+    name_translations: dict[str, str],
+    display_order: int,
+) -> None:
+    stmt = (
+        pg_insert(ACTIVITY_CATEGORIES)
+        .values(
+            id=category_id,
+            parent_id=None,
+            name=name,
+            name_translations=name_translations,
+            display_order=display_order,
+        )
+        .on_conflict_do_nothing(index_elements=["id"])
+    )
+    connection.execute(stmt)
 
 
 def upgrade() -> None:
     """Insert HK regions, reparent districts, and seed wizard categories."""
+    connection = op.get_bind()
+    hk_country_id = _hk_country_id(connection)
+
     _insert_region(
+        connection,
+        hk_country_id,
         HK_ISLAND_ID,
         "Hong Kong Island",
         "hk_island",
@@ -118,6 +192,8 @@ def upgrade() -> None:
         1,
     )
     _insert_region(
+        connection,
+        hk_country_id,
         KOWLOON_ID,
         "Kowloon",
         "hk_kowloon",
@@ -126,6 +202,8 @@ def upgrade() -> None:
         2,
     )
     _insert_region(
+        connection,
+        hk_country_id,
         NEW_TERRITORIES_ID,
         "New Territories",
         "hk_new_territories",
@@ -134,6 +212,8 @@ def upgrade() -> None:
         3,
     )
     _insert_region(
+        connection,
+        hk_country_id,
         ISLANDS_ID,
         "Islands",
         "hk_islands",
@@ -142,119 +222,87 @@ def upgrade() -> None:
         4,
     )
 
-    _reparent_districts(HK_ISLAND_ID, HK_ISLAND_DISTRICTS)
-    _reparent_districts(KOWLOON_ID, KOWLOON_DISTRICTS)
-    _reparent_districts(NEW_TERRITORIES_ID, NEW_TERRITORIES_DISTRICTS)
-    _reparent_districts(ISLANDS_ID, ISLANDS_DISTRICTS)
-
-    for category_id, name, translations, display_order in (
-        (
-            WORKSHOP_CATEGORY_ID,
-            "Workshop",
-            '{"en": "Workshop", "zh-HK": "工作坊"}',
-            2,
-        ),
-        (
-            CLASS_CATEGORY_ID,
-            "Class",
-            '{"en": "Class", "zh-HK": "課程"}',
-            3,
-        ),
-        (
-            OUTDOOR_CATEGORY_ID,
-            "Outdoor activity",
-            '{"en": "Outdoor activity", "zh-HK": "戶外活動"}',
-            4,
-        ),
-        (
-            INDOOR_CATEGORY_ID,
-            "Indoor fun",
-            '{"en": "Indoor fun", "zh-HK": "室內玩樂"}',
-            5,
-        ),
-    ):
-        op.execute(
-            f"""
-            INSERT INTO activity_categories (
-                id, parent_id, name, name_translations, display_order
-            )
-            SELECT '{category_id}'::uuid, NULL, '{name}',
-                   '{translations}'::jsonb, {display_order}
-            WHERE NOT EXISTS (
-                SELECT 1 FROM activity_categories
-                WHERE id = '{category_id}'::uuid
-            )
-            """
-        )
-
-    op.execute(
-        sa.text(
-            f"""
-            UPDATE activities
-            SET category_id = '{WORKSHOP_CATEGORY_ID}'::uuid
-            WHERE id = 'dddddddd-dddd-dddd-dddd-dddddddddddd'
-            """
-        )
+    _reparent_districts(connection, hk_country_id, HK_ISLAND_ID, HK_ISLAND_DISTRICTS)
+    _reparent_districts(connection, hk_country_id, KOWLOON_ID, KOWLOON_DISTRICTS)
+    _reparent_districts(
+        connection,
+        hk_country_id,
+        NEW_TERRITORIES_ID,
+        NEW_TERRITORIES_DISTRICTS,
     )
-    op.execute(
-        sa.text(
-            f"""
-            UPDATE activities
-            SET category_id = '{CLASS_CATEGORY_ID}'::uuid
-            WHERE id = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'
-            """
-        )
+    _reparent_districts(connection, hk_country_id, ISLANDS_ID, ISLANDS_DISTRICTS)
+
+    _insert_category(
+        connection,
+        WORKSHOP_CATEGORY_ID,
+        "Workshop",
+        {"en": "Workshop", "zh-HK": "工作坊"},
+        2,
+    )
+    _insert_category(
+        connection,
+        CLASS_CATEGORY_ID,
+        "Class",
+        {"en": "Class", "zh-HK": "課程"},
+        3,
+    )
+    _insert_category(
+        connection,
+        OUTDOOR_CATEGORY_ID,
+        "Outdoor activity",
+        {"en": "Outdoor activity", "zh-HK": "戶外活動"},
+        4,
+    )
+    _insert_category(
+        connection,
+        INDOOR_CATEGORY_ID,
+        "Indoor fun",
+        {"en": "Indoor fun", "zh-HK": "室內玩樂"},
+        5,
+    )
+
+    connection.execute(
+        sa.update(ACTIVITIES)
+        .where(ACTIVITIES.c.id == PAINTING_ACTIVITY_ID)
+        .values(category_id=WORKSHOP_CATEGORY_ID)
+    )
+    connection.execute(
+        sa.update(ACTIVITIES)
+        .where(ACTIVITIES.c.id == DANCE_ACTIVITY_ID)
+        .values(category_id=CLASS_CATEGORY_ID)
     )
 
 
 def downgrade() -> None:
     """Restore flat HK districts and remove wizard categories."""
-    op.execute(
-        """
-        UPDATE activities
-        SET category_id = '99999999-9999-9999-9999-999999999999'
-        WHERE id IN (
-            'dddddddd-dddd-dddd-dddd-dddddddddddd',
-            'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'
-        )
-        """
-    )
-    op.execute(
-        f"""
-        DELETE FROM activity_categories
-        WHERE id IN (
-            '{WORKSHOP_CATEGORY_ID}'::uuid,
-            '{CLASS_CATEGORY_ID}'::uuid,
-            '{OUTDOOR_CATEGORY_ID}'::uuid,
-            '{INDOOR_CATEGORY_ID}'::uuid
-        )
-        """
+    connection = op.get_bind()
+    hk_country_id = _hk_country_id(connection)
+    region_ids = (HK_ISLAND_ID, KOWLOON_ID, NEW_TERRITORIES_ID, ISLANDS_ID)
+    wizard_category_ids = (
+        WORKSHOP_CATEGORY_ID,
+        CLASS_CATEGORY_ID,
+        OUTDOOR_CATEGORY_ID,
+        INDOOR_CATEGORY_ID,
     )
 
-    op.execute(
-        f"""
-        UPDATE geographic_areas AS district
-        SET parent_id = hk.id
-        FROM geographic_areas hk
-        WHERE hk.code = 'HK'
-          AND hk.level = 'country'
-          AND district.level = 'district'
-          AND district.parent_id IN (
-              '{HK_ISLAND_ID}'::uuid,
-              '{KOWLOON_ID}'::uuid,
-              '{NEW_TERRITORIES_ID}'::uuid,
-              '{ISLANDS_ID}'::uuid
-          )
-        """
+    connection.execute(
+        sa.update(ACTIVITIES)
+        .where(ACTIVITIES.c.id.in_([PAINTING_ACTIVITY_ID, DANCE_ACTIVITY_ID]))
+        .values(category_id=SPORT_CATEGORY_ID)
     )
-    op.execute(
-        f"""
-        DELETE FROM geographic_areas
-        WHERE id IN (
-            '{HK_ISLAND_ID}'::uuid,
-            '{KOWLOON_ID}'::uuid,
-            '{NEW_TERRITORIES_ID}'::uuid,
-            '{ISLANDS_ID}'::uuid
+    connection.execute(
+        sa.delete(ACTIVITY_CATEGORIES).where(
+            ACTIVITY_CATEGORIES.c.id.in_(wizard_category_ids)
         )
-        """
     )
+    connection.execute(
+        sa.update(GEO_AREAS)
+        .where(
+            sa.and_(
+                GEO_AREAS.c.level == "district",
+                GEO_AREAS.c.parent_id.in_(region_ids),
+            )
+        )
+        .values(parent_id=hk_country_id)
+    )
+    connection.execute(sa.delete(GEO_AREAS).where(GEO_AREAS.c.id.in_(region_ids)))

--- a/backend/src/app/api/schemas.py
+++ b/backend/src/app/api/schemas.py
@@ -32,6 +32,7 @@ class LocationSchema(BaseModel):
 
     id: str
     area_id: str
+    region_area_id: Optional[str]
     address: Optional[str]
     lat: Optional[Decimal]
     lng: Optional[Decimal]
@@ -49,6 +50,7 @@ class ActivitySchema(BaseModel):
     description_translations: dict[str, str]
     age_min: Optional[int]
     age_max: Optional[int]
+    category_id: Optional[str]
 
 
 class PricingSchema(BaseModel):

--- a/backend/src/app/api/search.py
+++ b/backend/src/app/api/search.py
@@ -12,6 +12,7 @@ from dataclasses import replace
 from typing import Any, Mapping
 from uuid import UUID
 
+from sqlalchemy import select
 from sqlalchemy.orm import Session, selectinload
 
 from app.api.schemas import (
@@ -29,6 +30,7 @@ from app.db.models import (
     Activity,
     ActivityPricing,
     ActivitySchedule,
+    GeographicArea,
     Location,
     Organization,
     PricingType,
@@ -42,7 +44,12 @@ from app.db.queries import (
 from app.exceptions import CursorError, ValidationError
 from app.utils import json_response, parse_decimal, parse_enum, parse_int
 from app.utils.logging import configure_logging, get_logger, set_request_context
-from app.utils.parsers import collect_query_params, first_param, parse_languages
+from app.utils.parsers import (
+    collect_query_params,
+    first_param,
+    parse_languages,
+    parse_uuid_list,
+)
 from app.utils.responses import get_cors_headers
 from app.utils.translations import build_translation_map
 
@@ -92,6 +99,7 @@ def parse_filters(event: Mapping[str, Any]) -> ActivitySearchFilters:
     return ActivitySearchFilters(
         age=parse_int(first_param(params, "age")),
         area_id=area_id,
+        category_ids=parse_uuid_list(params.get("category_id", [])),
         pricing_type=parse_enum(first_param(params, "pricing_type"), PricingType),
         price_min=parse_decimal(first_param(params, "price_min")),
         price_max=parse_decimal(first_param(params, "price_max")),
@@ -122,10 +130,11 @@ def fetch_search_response(
 
     with Session(engine) as session:
         rows = session.execute(query).all()
+        region_cache = _load_region_area_cache(session)
 
     has_more = len(rows) > requested_limit
     trimmed_rows = rows[:requested_limit]
-    items = [map_row_to_result(row) for row in trimmed_rows]
+    items = [map_row_to_result(row, region_cache) for row in trimmed_rows]
     next_cursor = None
     if has_more and trimmed_rows:
         last_row = trimmed_rows[-1]
@@ -136,7 +145,10 @@ def fetch_search_response(
     return ActivitySearchResponseSchema(items=items, next_cursor=next_cursor)
 
 
-def map_row_to_result(row: Any) -> ActivitySearchResultSchema:
+def map_row_to_result(
+    row: Any,
+    region_cache: dict[str, str | None],
+) -> ActivitySearchResultSchema:
     """Map a SQLAlchemy row to a search result schema."""
 
     mapping = row._mapping
@@ -161,6 +173,7 @@ def map_row_to_result(row: Any) -> ActivitySearchResultSchema:
             ),
             age_min=age_min,
             age_max=age_max,
+            category_id=str(activity.category_id),
         ),
         organization=OrganizationSchema(
             id=str(organization.id),
@@ -179,6 +192,7 @@ def map_row_to_result(row: Any) -> ActivitySearchResultSchema:
         location=LocationSchema(
             id=str(location.id),
             area_id=str(location.area_id),
+            region_area_id=region_cache.get(str(location.area_id)),
             address=location.address,
             lat=location.lat,
             lng=location.lng,
@@ -218,6 +232,36 @@ def _serialize_weekly_entries(
         )
         for entry in entries
     ]
+
+
+def _load_region_area_cache(session: Session) -> dict[str, str | None]:
+    """Map each geographic area id to its level=region ancestor id."""
+
+    areas = session.execute(select(GeographicArea)).scalars().all()
+    by_id = {str(area.id): area for area in areas}
+    cache: dict[str, str | None] = {}
+
+    def resolve_region(area_id: str) -> str | None:
+        if area_id in cache:
+            return cache[area_id]
+        area = by_id.get(area_id)
+        if area is None:
+            cache[area_id] = None
+            return None
+        if area.level == "region":
+            cache[area_id] = area_id
+            return area_id
+        if area.parent_id is None:
+            cache[area_id] = None
+            return None
+        parent_key = str(area.parent_id)
+        resolved = resolve_region(parent_key)
+        cache[area_id] = resolved
+        return resolved
+
+    for area_key in by_id:
+        resolve_region(area_key)
+    return cache
 
 
 def _extract_age_bounds(age_range: Any) -> tuple[int | None, int | None]:

--- a/backend/src/app/db/queries.py
+++ b/backend/src/app/db/queries.py
@@ -18,6 +18,7 @@ from app.db.models import Activity
 from app.db.models import ActivityPricing
 from app.db.models import ActivitySchedule
 from app.db.models import ActivityScheduleEntry
+from app.db.models import GeographicArea
 from app.db.models import Location
 from app.db.models import Organization
 from app.db.models import PricingType
@@ -39,6 +40,7 @@ class ActivitySearchFilters:
 
     age: int | None = None
     area_id: UUID | None = None
+    category_ids: Sequence[UUID] = ()
     pricing_type: PricingType | None = None
     price_min: Decimal | None = None
     price_max: Decimal | None = None
@@ -101,7 +103,11 @@ def build_search_query(filters: ActivitySearchFilters) -> Select:
         conditions.append(Activity.age_range.contains(filters.age))
 
     if filters.area_id is not None:
-        conditions.append(Location.area_id == filters.area_id)
+        area_ids = _area_descendant_ids_subquery(filters.area_id)
+        conditions.append(Location.area_id.in_(area_ids))
+
+    if filters.category_ids:
+        conditions.append(Activity.category_id.in_(filters.category_ids))
 
     if filters.pricing_type is not None:
         conditions.append(ActivityPricing.pricing_type == filters.pricing_type)
@@ -229,3 +235,19 @@ def _cursor_values(cursor: ActivitySearchCursor) -> list:
         cursor.start_minutes_utc,
         cursor.schedule_id,
     ]
+
+
+def _area_descendant_ids_subquery(area_id: UUID) -> sa.ScalarSelect:
+    """Return a subquery of area IDs including descendants."""
+
+    base = (
+        select(GeographicArea.id)
+        .where(GeographicArea.id == area_id)
+        .cte(recursive=True)
+    )
+    geographic_areas = GeographicArea.__table__
+    recursive = select(geographic_areas.c.id).where(
+        geographic_areas.c.parent_id == base.c.id
+    )
+    area_tree = base.union_all(recursive)
+    return select(area_tree.c.id)

--- a/backend/src/app/db/queries.py
+++ b/backend/src/app/db/queries.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from decimal import Decimal
+from typing import Any
 from typing import Iterable
 from typing import Sequence
 from uuid import UUID
@@ -237,7 +238,7 @@ def _cursor_values(cursor: ActivitySearchCursor) -> list:
     ]
 
 
-def _area_descendant_ids_subquery(area_id: UUID) -> sa.ScalarSelect:
+def _area_descendant_ids_subquery(area_id: UUID) -> Select[Any]:
     """Return a subquery of area IDs including descendants."""
 
     base = (

--- a/backend/src/app/utils/parsers.py
+++ b/backend/src/app/utils/parsers.py
@@ -10,6 +10,7 @@ from typing import Mapping
 from typing import Optional
 from typing import Sequence
 from typing import TypeVar
+from uuid import UUID
 
 T = TypeVar("T", bound=Enum)
 
@@ -84,6 +85,21 @@ def parse_enum(value: Optional[str], enum_type: type[T]) -> Optional[T]:
     if value is None or value == "":
         return None
     return enum_type(value)
+
+
+def parse_uuid_list(values: Sequence[str]) -> list[UUID]:
+    """Parse UUID filters from repeated or comma-separated values."""
+
+    parsed: list[UUID] = []
+    for value in values:
+        for item in value.split(","):
+            item = item.strip()
+            if not item:
+                continue
+            uuid_value = UUID(item)
+            if uuid_value not in parsed:
+                parsed.append(uuid_value)
+    return parsed
 
 
 def parse_languages(values: Sequence[str]) -> list[str]:

--- a/docs/api/search.yaml
+++ b/docs/api/search.yaml
@@ -49,10 +49,25 @@ paths:
         - name: area_id
           in: query
           required: false
-          description: Filter by geographic area UUID
+          description: |
+            Filter by geographic area UUID. Matches activities in the given area
+            or any descendant area (for example a region or district).
           schema:
             type: string
             format: uuid
+        - name: category_id
+          in: query
+          required: false
+          description: |
+            Filter by activity category UUID. Multiple values allowed; results
+            match any listed category.
+          style: form
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+              format: uuid
         - name: pricing_type
           in: query
           required: false
@@ -238,7 +253,14 @@ components:
         area_id:
           type: string
           format: uuid
-          description: Geographic area UUID (leaf node)
+          description: Geographic area UUID (leaf district node)
+        region_area_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: |
+            Macro-region ancestor UUID (for example Hong Kong Island) when the
+            location district belongs to a region node.
         address:
           type: string
           nullable: true
@@ -270,6 +292,10 @@ components:
         age_max:
           type: integer
           nullable: true
+        category_id:
+          type: string
+          format: uuid
+          description: Activity category UUID
     Pricing:
       type: object
       required: [pricing_type, amount, currency, free_trial_class_offered]

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -52,6 +52,10 @@ Constraints:
 
 Purpose: Hierarchical lookup of valid geographic areas (country > region > city > district).
 
+Hong Kong uses four `level=region` nodes (Hong Kong Island, Kowloon, New Territories,
+Islands) between the `HK` country row and the 18 district rows. Home wizard region
+choices reference these region UUIDs; search matches any descendant district.
+
 Columns:
 - `id` (UUID, PK, default `gen_random_uuid()`)
 - `parent_id` (UUID, FK -> geographic_areas.id, cascade delete, nullable for countries)

--- a/shared/home_wizard/home_wizard_choices.json
+++ b/shared/home_wizard/home_wizard_choices.json
@@ -1,0 +1,103 @@
+{
+  "version": 1,
+  "activityTypes": [
+    {
+      "id": "workshop",
+      "categoryId": "c1111111-1111-1111-1111-111111111101",
+      "labels": {
+        "en": "Workshop",
+        "zh-HK": "工作坊"
+      }
+    },
+    {
+      "id": "class",
+      "categoryId": "c1111111-1111-1111-1111-111111111102",
+      "labels": {
+        "en": "Class",
+        "zh-HK": "課程"
+      }
+    },
+    {
+      "id": "outdoor",
+      "categoryId": "c1111111-1111-1111-1111-111111111103",
+      "labels": {
+        "en": "Outdoor activity",
+        "zh-HK": "戶外活動"
+      }
+    },
+    {
+      "id": "indoor",
+      "categoryId": "c1111111-1111-1111-1111-111111111104",
+      "labels": {
+        "en": "Indoor fun",
+        "zh-HK": "室內玩樂"
+      }
+    }
+  ],
+  "ageGroups": [
+    {
+      "id": "1-3",
+      "searchAge": 2,
+      "minAge": 1,
+      "maxAge": 3,
+      "labels": {
+        "en": "1–3 years",
+        "zh-HK": "1–3歲"
+      }
+    },
+    {
+      "id": "3-6",
+      "searchAge": 4,
+      "minAge": 3,
+      "maxAge": 6,
+      "labels": {
+        "en": "3–6 years",
+        "zh-HK": "3–6歲"
+      }
+    },
+    {
+      "id": "6-12",
+      "searchAge": 9,
+      "minAge": 6,
+      "maxAge": 12,
+      "labels": {
+        "en": "6–12 years",
+        "zh-HK": "6–12歲"
+      }
+    }
+  ],
+  "regions": [
+    {
+      "id": "hong_kong_island",
+      "areaId": "a1111111-1111-1111-1111-111111111101",
+      "labels": {
+        "en": "Hong Kong Island",
+        "zh-HK": "香港島"
+      }
+    },
+    {
+      "id": "kowloon",
+      "areaId": "a1111111-1111-1111-1111-111111111102",
+      "labels": {
+        "en": "Kowloon",
+        "zh-HK": "九龍"
+      }
+    },
+    {
+      "id": "new_territories",
+      "areaId": "a1111111-1111-1111-1111-111111111103",
+      "labels": {
+        "en": "New Territories",
+        "zh-HK": "新界"
+      }
+    },
+    {
+      "id": "islands",
+      "areaId": "a1111111-1111-1111-1111-111111111104",
+      "labels": {
+        "en": "Islands",
+        "zh-HK": "離島"
+      }
+    }
+  ]
+}

--- a/tests/test_search_category_filter.py
+++ b/tests/test_search_category_filter.py
@@ -1,0 +1,42 @@
+"""Tests for search category and area tree filters."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "backend" / "src"))
+
+from app.db.queries import ActivitySearchFilters  # noqa: E402
+from app.db.queries import build_search_query  # noqa: E402
+from app.utils.parsers import parse_uuid_list  # noqa: E402
+
+
+def test_parse_uuid_list_deduplicates() -> None:
+    """Repeated category ids are parsed once."""
+
+    category_id = str(uuid4())
+    parsed = parse_uuid_list([category_id, category_id])
+    assert len(parsed) == 1
+
+
+def test_build_search_query_applies_category_filter() -> None:
+    """Category ids appear in the generated SQL."""
+
+    category_id = uuid4()
+    filters = ActivitySearchFilters(category_ids=[category_id])
+    query = build_search_query(filters)
+    where_clause = str(query.whereclause)
+    assert "activities.category_id" in where_clause
+
+
+def test_build_search_query_applies_area_tree_filter() -> None:
+    """Area id uses a recursive geographic area subquery."""
+
+    filters = ActivitySearchFilters(area_id=uuid4())
+    query = build_search_query(filters)
+    where_clause = str(query.whereclause)
+    assert "geographic_areas" in where_clause


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the approved home wizard flow on **Flutter** and **public_www**:

1. **Activity types** (multi-select) → Continue
2. **Child age** (single) → background search prefetch
3. **Macro region** (single) → instant client filter + free-text search on results

Choices come from `shared/home_wizard/home_wizard_choices.json` (bundled in Flutter assets; copied to `apps/public_www/src/data/` for the public site build).

## modern-web-guidance (`forms` guide)

Public www wizard now follows the retrieved **forms** best practices:

- `<form>` + `<fieldset>` / `<legend>` per step
- Native **checkboxes** (multi activity types) and **radios** (age, region) for ≤5 options
- Visible `<label htmlFor="…">` associations (not placeholder-only)
- `role="search"` + `type="search"` + `enterKeyHint="search"` for free-text filter
- `aria-live="polite"` for loading/empty states; `role="alert"` for errors
- `:focus-within` outline via Tailwind (no inline `style`)

## Database

- Migration `0028_hk_regions_wizard`: HK macro **regions** in `geographic_areas`, districts reparented, wizard categories seeded.
- **Seed assessment:** `seed_data.sql` unchanged.

## Search API

- `category_id` (repeatable), recursive `area_id`, `category_id` + `region_area_id` on responses.

## Deploy notes

- Run `alembic upgrade head` before release.
- Public site search env (optional until API wired): `NEXT_PUBLIC_SEARCH_API_BASE_URL`, `NEXT_PUBLIC_SEARCH_API_KEY`, `NEXT_PUBLIC_DEVICE_ATTESTATION_TOKEN`.

## Tests

- `tests/test_search_category_filter.py`
- `apps/public_www/tests/**` (14 passing)
- `apps/siutindei_app/test/home_wizard_choices_test.dart`

## Mobile screenshot (Chrome headless 390×844)

Built static export served locally; wizard section at `#home-wizard`:

[Mobile home wizard — activity type step](https://cursor.com/agents/bc-319875e6-7777-434e-8a8b-b4dddc34af7e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpublic-www-mobile-wizard-en.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-319875e6-7777-434e-8a8b-b4dddc34af7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-319875e6-7777-434e-8a8b-b4dddc34af7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

