### PR TITLE
fix(public_www): CSP script hashes so home wizard hydrates on staging

### DIFF
--- a/apps/public_www/scripts/csp-inline-script-hashes.mjs
+++ b/apps/public_www/scripts/csp-inline-script-hashes.mjs
@@ -1,0 +1,67 @@
+// Collects CSP sha256- hashes for inline <script> bodies in static HTML.
+// Next.js static export embeds flight/hydration payloads as inline scripts;
+// script-src 'self' alone blocks them and prevents React from hydrating.
+
+import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const INLINE_SCRIPT_PATTERN =
+  /<script(?![^>]*\bsrc=)([^>]*)>([\s\S]*?)<\/script>/gi;
+
+/**
+ * @param {string} scriptBody
+ * @returns {string}
+ */
+export function hashInlineScriptBody(scriptBody) {
+  const digest = createHash('sha256')
+    .update(scriptBody, 'utf8')
+    .digest('base64');
+  return `'sha256-${digest}'`;
+}
+
+/**
+ * @param {string} html
+ * @returns {string[]}
+ */
+export function collectInlineScriptHashesFromHtml(html) {
+  const hashes = new Set();
+  for (const match of html.matchAll(INLINE_SCRIPT_PATTERN)) {
+    const body = match[2];
+    if (!body.trim()) {
+      continue;
+    }
+    hashes.add(hashInlineScriptBody(body));
+  }
+  return [...hashes];
+}
+
+/**
+ * @param {string} outDir
+ * @returns {Promise<string[]>}
+ */
+export async function collectInlineScriptHashesFromOutDir(outDir) {
+  const hashes = new Set();
+  for await (const filePath of walkHtmlFiles(outDir)) {
+    const html = await fs.readFile(filePath, 'utf8');
+    for (const hash of collectInlineScriptHashesFromHtml(html)) {
+      hashes.add(hash);
+    }
+  }
+  return [...hashes].sort();
+}
+
+/**
+ * @param {string} dir
+ */
+async function* walkHtmlFiles(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkHtmlFiles(fullPath);
+    } else if (entry.isFile() && entry.name.endsWith('.html')) {
+      yield fullPath;
+    }
+  }
+}

--- a/apps/public_www/scripts/inject-csp-meta.mjs
+++ b/apps/public_www/scripts/inject-csp-meta.mjs
@@ -1,9 +1,12 @@
 // Inserts a <meta http-equiv="Content-Security-Policy"> tag into every
 // generated HTML in the static export. Aligns with evolvesprouts: extend
 // script-src / connect-src when GTM or Meta Pixel init scripts are enabled.
+// Next.js inline flight scripts are allowed via build-time sha256- hashes.
 
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
+
+import { collectInlineScriptHashesFromOutDir } from './csp-inline-script-hashes.mjs';
 
 const OUT_DIR = path.resolve('out');
 const META_MARKER = '<!-- csp-meta -->';
@@ -24,11 +27,14 @@ const GTM_CONNECT_ORIGINS = [
 const META_PIXEL_SCRIPT_ORIGINS = ['https://connect.facebook.net'];
 const META_PIXEL_CONNECT_ORIGINS = ['https://www.facebook.com'];
 
-function buildCspDirectives() {
+/**
+ * @param {string[]} inlineScriptHashes
+ */
+function buildCspDirectives(inlineScriptHashes) {
   const hasGtm = Boolean(process.env.NEXT_PUBLIC_GTM_ID?.trim());
   const hasMetaPixel = Boolean(process.env.NEXT_PUBLIC_META_PIXEL_ID?.trim());
 
-  const scriptSources = ["'self'"];
+  const scriptSources = ["'self'", ...inlineScriptHashes];
   const connectSources = ["'self'"];
 
   if (hasGtm) {
@@ -65,6 +71,10 @@ async function* walk(dir) {
   }
 }
 
+/**
+ * @param {string} filePath
+ * @param {string} metaTag
+ */
 async function injectIntoFile(filePath, metaTag) {
   const original = await fs.readFile(filePath, 'utf8');
   if (original.includes(META_MARKER)) {
@@ -88,7 +98,14 @@ async function main() {
     process.exit(1);
   }
 
-  const metaTag = `<meta http-equiv="Content-Security-Policy" content="${buildCspDirectives()}">`;
+  const inlineScriptHashes = await collectInlineScriptHashesFromOutDir(OUT_DIR);
+  if (inlineScriptHashes.length === 0) {
+    console.warn(
+      'csp:inject — no inline script hashes found; hydration may be blocked.',
+    );
+  }
+
+  const metaTag = `<meta http-equiv="Content-Security-Policy" content="${buildCspDirectives(inlineScriptHashes)}">`;
   let updatedCount = 0;
   let totalCount = 0;
   for await (const filePath of walk(OUT_DIR)) {
@@ -98,7 +115,10 @@ async function main() {
       updatedCount += 1;
     }
   }
-  console.log(`csp:inject — ${updatedCount}/${totalCount} HTML files updated.`);
+  console.log(
+    `csp:inject — ${updatedCount}/${totalCount} HTML files updated ` +
+      `(${inlineScriptHashes.length} inline script hashes).`,
+  );
 }
 
 main().catch((error) => {

--- a/apps/public_www/scripts/validate-csp-meta.mjs
+++ b/apps/public_www/scripts/validate-csp-meta.mjs
@@ -5,6 +5,8 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
+import { collectInlineScriptHashesFromHtml } from './csp-inline-script-hashes.mjs';
+
 const OUT_DIR = path.resolve('out');
 const META_MARKER = '<!-- csp-meta -->';
 
@@ -20,17 +22,43 @@ async function* walk(dir) {
   }
 }
 
+/**
+ * @param {string} contents
+ */
+function readCspMetaContent(contents) {
+  const match = contents.match(
+    /<meta\s+http-equiv="Content-Security-Policy"\s+content="([^"]*)"/i,
+  );
+  return match?.[1] ?? null;
+}
+
 async function main() {
   const missing = [];
+  const missingHashes = [];
   for await (const filePath of walk(OUT_DIR)) {
     const contents = await fs.readFile(filePath, 'utf8');
     if (!contents.includes(META_MARKER)) {
       missing.push(filePath);
+      continue;
+    }
+    const csp = readCspMetaContent(contents);
+    const inlineHashes = collectInlineScriptHashesFromHtml(contents);
+    if (inlineHashes.length > 0 && csp && !csp.includes('sha256-')) {
+      missingHashes.push(filePath);
     }
   }
   if (missing.length > 0) {
     console.error('csp:validate — HTML files without CSP meta:');
     for (const filePath of missing) {
+      console.error(`- ${filePath}`);
+    }
+    process.exit(1);
+  }
+  if (missingHashes.length > 0) {
+    console.error(
+      'csp:validate — HTML with inline scripts but no sha256- in CSP:',
+    );
+    for (const filePath of missingHashes) {
       console.error(`- ${filePath}`);
     }
     process.exit(1);

--- a/apps/public_www/tests/scripts/csp-inline-script-hashes.test.mjs
+++ b/apps/public_www/tests/scripts/csp-inline-script-hashes.test.mjs
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  collectInlineScriptHashesFromHtml,
+  hashInlineScriptBody,
+} from '../../scripts/csp-inline-script-hashes.mjs';
+
+describe('csp-inline-script-hashes', () => {
+  it('hashes inline script bodies for CSP script-src', () => {
+    const body = 'self.__next_f.push([1,"test"])';
+    const hash = hashInlineScriptBody(body);
+    expect(hash).toMatch(/^'sha256-[A-Za-z0-9+/]+={0,2}'$/);
+    expect(collectInlineScriptHashesFromHtml(
+      `<script>${body}</script>`,
+    )).toContain(hash);
+  });
+
+  it('ignores external script tags', () => {
+    const html =
+      '<script src="/_next/static/chunks/app.js"></script>' +
+      '<script>inline()</script>';
+    const hashes = collectInlineScriptHashesFromHtml(html);
+    expect(hashes).toHaveLength(1);
+    expect(hashes[0]).toBe(hashInlineScriptBody('inline()'));
+  });
+
+  it('skips empty inline script tags', () => {
+    expect(collectInlineScriptHashesFromHtml('<script></script>')).toEqual([]);
+  });
+});

--- a/docs/architecture/public-www.md
+++ b/docs/architecture/public-www.md
@@ -157,18 +157,25 @@ response. The HTML produced by `next build` *also* carries an inline CSP
 even when an HTML file is rendered outside CloudFront (local QA, opened
 from disk, archived snapshot).
 
-Both CSPs are aligned to the same baseline:
+The HTML meta CSP baseline (see `scripts/inject-csp-meta.mjs`) is:
 
 ```
-default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline';
-script-src 'self'; font-src 'self' data:; connect-src 'self';
+default-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline';
+script-src 'self' 'sha256-…' …; font-src 'self' data:; connect-src 'self';
 base-uri 'self'; object-src 'none'; frame-ancestors 'none';
 ```
 
-`'unsafe-inline'` is allowed for `style-src` to keep critical-CSS friendly;
-inline scripts and inline event handlers are not allowed and are blocked
-both at CSP layer and via the `.cursorrules` "no `dangerouslySetInnerHTML`,
-no `eval`" rule.
+`'unsafe-inline'` is allowed for `style-src` to keep critical-CSS friendly.
+Next.js static export embeds required inline flight/hydration scripts; the
+build collects a `sha256-` hash for each unique inline script body across
+`out/**/*.html` and adds those hashes to `script-src` so React can hydrate
+without allowing arbitrary inline script. Ad-hoc inline scripts and inline
+event handlers remain disallowed via the `.cursorrules` "no
+`dangerouslySetInnerHTML`, no `eval`" rule.
+
+CloudFront’s response headers policy applies a smaller CSP fragment
+(`base-uri`, `object-src`, `frame-ancestors` only); the meta tag carries
+the full policy above.
 
 ## Future work — `/www/*` API proxy
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On staging (`siutindei-www-staging.lx-software.com`), selecting an activity type in the home wizard **looks** selected (CSS `peer-checked`) but **Continue stays disabled** and the flow cannot advance.

## Root cause

The build injects a CSP meta tag with `script-src 'self'`. Next.js static export also emits **inline** flight/hydration scripts. The browser blocks those scripts, so **React never hydrates** and wizard state never updates.

Local `next dev` does not inject this CSP meta tag, which is why the bug only appears on deployed static builds.

## Fix

- Collect `sha256-` hashes for every unique inline `<script>` body across `out/**/*.html` at build time.
- Add those hashes to `script-src` in `inject-csp-meta.mjs`.
- Validate that pages with inline scripts include `sha256-` in their CSP meta.
- Document the behavior in `docs/architecture/public-www.md`.

## Verification

- `npm run build` reports 42 inline script hashes injected.
- Static serve of `out/` at localhost:8765: Workshop enables Continue and advances to age step; no `script-src` CSP violations in console.

## After merge

Merge to `main` triggers **Deploy Public Website Staging** (paths under `apps/public_www/**`). Staging will pick up the fix automatically once that workflow completes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c45287b2-644d-44f9-950b-fb56d8b3e274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c45287b2-644d-44f9-950b-fb56d8b3e274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

