### PR TITLE
Remove style-src unsafe-inline from public www CSP

### DIFF
--- a/apps/public_www/public/scripts/show-staging-badge.js
+++ b/apps/public_www/public/scripts/show-staging-badge.js
@@ -9,18 +9,5 @@
   badge.id = 'staging-badge';
   badge.textContent = 'STAGING';
   badge.setAttribute('role', 'status');
-  badge.style.position = 'fixed';
-  badge.style.bottom = '12px';
-  badge.style.right = '12px';
-  badge.style.zIndex = '9999';
-  badge.style.padding = '6px 10px';
-  badge.style.borderRadius = '999px';
-  badge.style.background = '#dc2626';
-  badge.style.color = '#fff';
-  badge.style.fontFamily = 'system-ui, sans-serif';
-  badge.style.fontSize = '12px';
-  badge.style.fontWeight = '700';
-  badge.style.letterSpacing = '0.1em';
-  badge.style.boxShadow = '0 4px 12px rgba(0,0,0,0.25)';
   document.body.appendChild(badge);
 })();

--- a/apps/public_www/scripts/inject-csp-meta.mjs
+++ b/apps/public_www/scripts/inject-csp-meta.mjs
@@ -49,7 +49,7 @@ function buildCspDirectives(inlineScriptHashes) {
   return [
     "default-src 'self'",
     `img-src 'self' data: https:`,
-    "style-src 'self' 'unsafe-inline'",
+    "style-src 'self'",
     `script-src ${[...new Set(scriptSources)].join(' ')}`,
     "font-src 'self' data:",
     `connect-src ${[...new Set(connectSources)].join(' ')}`,

--- a/apps/public_www/src/app/globals.css
+++ b/apps/public_www/src/app/globals.css
@@ -34,6 +34,26 @@ button:focus-visible {
   border-radius: 4px;
 }
 
+body.navbar-mobile-menu-scroll-lock {
+  overflow: hidden;
+}
+
+#staging-badge {
+  position: fixed;
+  bottom: 12px;
+  right: 12px;
+  z-index: 9999;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: #dc2626;
+  color: #fff;
+  font-family: system-ui, sans-serif;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+}
+
 /* Page grid cells use data attributes so placement works in static export
    (Tailwind cannot emit dynamically built col-[n_/span_m] utilities). */
 .page-body-grid__cell {

--- a/apps/public_www/src/components/sections/navbar-mobile-menu.tsx
+++ b/apps/public_www/src/components/sections/navbar-mobile-menu.tsx
@@ -45,8 +45,9 @@ export function NavbarMobileMenu({ locale, content }: NavbarMobileMenuProps) {
       return;
     }
 
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
+    const scrollLockClass = 'navbar-mobile-menu-scroll-lock';
+    const hadScrollLock = document.body.classList.contains(scrollLockClass);
+    document.body.classList.add(scrollLockClass);
 
     const main = document.getElementById('main-content');
     const footer = document.getElementById('contact');
@@ -95,7 +96,9 @@ export function NavbarMobileMenu({ locale, content }: NavbarMobileMenuProps) {
     document.addEventListener('keydown', onKeyDown);
 
     return () => {
-      document.body.style.overflow = previousOverflow;
+      if (!hadScrollLock) {
+        document.body.classList.remove(scrollLockClass);
+      }
       inertTargets.forEach((element, index) => {
         if (hadInert[index]) {
           element.setAttribute('inert', '');

--- a/apps/public_www/tests/components/navbar-mobile-menu.test.tsx
+++ b/apps/public_www/tests/components/navbar-mobile-menu.test.tsx
@@ -38,11 +38,15 @@ describe('NavbarMobileMenu', () => {
     expect(document.getElementById('contact')?.hasAttribute('inert')).toBe(
       true,
     );
+    expect(document.body.classList.contains('navbar-mobile-menu-scroll-lock'))
+      .toBe(true);
 
     fireEvent.keyDown(document, { key: 'Escape' });
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     expect(main?.hasAttribute('inert')).toBe(false);
+    expect(document.body.classList.contains('navbar-mobile-menu-scroll-lock'))
+      .toBe(false);
   });
 
   it('closes when the backdrop is clicked', () => {

--- a/docs/architecture/public-www.md
+++ b/docs/architecture/public-www.md
@@ -160,12 +160,15 @@ from disk, archived snapshot).
 The HTML meta CSP baseline (see `scripts/inject-csp-meta.mjs`) is:
 
 ```
-default-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline';
+default-src 'self'; img-src 'self' data: https:; style-src 'self';
 script-src 'self' 'sha256-…' …; font-src 'self' data:; connect-src 'self';
 base-uri 'self'; object-src 'none'; frame-ancestors 'none';
 ```
 
-`'unsafe-inline'` is allowed for `style-src` to keep critical-CSS friendly.
+Styles load from external stylesheets (`/_next/static/chunks/*.css` and
+`globals.css`); the app forbids JSX `style={...}` attributes. Scroll lock
+and the optional staging badge use CSS classes instead of JS-assigned
+inline styles so `style-src` does not need `'unsafe-inline'`.
 Next.js static export embeds required inline flight/hydration scripts; the
 build collects a `sha256-` hash for each unique inline script body across
 `out/**/*.html` and adds those hashes to `script-src` so React can hydrate


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes `'unsafe-inline'` from the public website HTML meta CSP `style-src` directive. The static export already loads all styles from external stylesheets; the only reason `'unsafe-inline'` was present was legacy/defensive allowance and two places that set styles via JavaScript.

## Why `'unsafe-inline'` was there

- Documented as "critical-CSS friendly" in `docs/architecture/public-www.md`
- In practice, the Next.js static export does **not** emit `<style>` tags or `style=""` attributes
- Two runtime code paths used `element.style.*`, which CSP treats as inline styles:
  - Mobile nav menu: `document.body.style.overflow = 'hidden'`
  - Staging badge script: many `badge.style.*` assignments

## Changes

- `style-src` is now `'self'` only (external CSS under `/_next/static/` and `globals.css`)
- Mobile menu scroll lock uses `body.navbar-mobile-menu-scroll-lock` class
- Staging badge uses `#staging-badge` rules in `globals.css` instead of JS inline styles
- Docs and navbar test updated

## Verification

- `npm test` in `apps/public_www` (17 tests)
- `npm run build` including `csp:inject` / `csp:validate`
- Built HTML contains no `unsafe-inline`

## Note on analytics

If `NEXT_PUBLIC_GTM_ID` or `NEXT_PUBLIC_META_PIXEL_ID` are enabled, third-party scripts may inject their own inline styles. That was already a separate concern from our app CSS; monitor analytics UI if those env vars are set in production.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5460b84a-d651-4690-a77b-4e84907a3390"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5460b84a-d651-4690-a77b-4e84907a3390"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

