### PR TITLE
Fix public website activity search env inlining

### DIFF
--- a/apps/public_www/src/components/pages/activity-detail-page.tsx
+++ b/apps/public_www/src/components/pages/activity-detail-page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 
 import type { Locale, SiteContent } from '@/content';
 import { Button } from '@/components/shared/ui/button';
+import { logActivityLoadError } from '@/lib/activities/load-error';
 import { fetchActivityListingById } from '@/lib/activities/search-client';
 import {
   formatListingPrice,
@@ -70,7 +71,8 @@ export function ActivityDetailPage({
         setListing(item);
         rememberViewedActivity(item.activity.id);
       })
-      .catch(() => {
+      .catch((error: unknown) => {
+        logActivityLoadError('activity detail', error);
         if (!cancelled) {
           setErrorMessage(copy.errorLabel);
           setListing(null);

--- a/apps/public_www/src/components/pages/search-results-page.tsx
+++ b/apps/public_www/src/components/pages/search-results-page.tsx
@@ -9,6 +9,7 @@ import { SearchMapPanel } from '@/components/sections/search/search-map-panel';
 import { ListingGrid } from '@/components/sections/listings/listing-grid';
 import { useSearchContext } from '@/components/shared/search/search-context';
 import { Chip } from '@/components/shared/ui/chip';
+import { logActivityLoadError } from '@/lib/activities/load-error';
 import { fetchActivitySearch } from '@/lib/activities/search-client';
 import {
   filtersToApiParams,
@@ -55,7 +56,8 @@ export function SearchResultsPage({ locale, copy }: SearchResultsPageProps) {
         matchesTextQuery(listing, locale, urlFilters.textQuery),
       );
       setListings(filtered);
-    } catch {
+    } catch (error: unknown) {
+      logActivityLoadError('search results', error);
       setErrorMessage(copy.errorLabel);
       setListings([]);
     } finally {

--- a/apps/public_www/src/components/sections/discovery/discovery-home-section.tsx
+++ b/apps/public_www/src/components/sections/discovery/discovery-home-section.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState } from 'react';
 import type { Locale, SiteContent } from '@/content';
 import { useSearchContext } from '@/components/shared/search/search-context';
 import { ListingCarouselSection } from '@/components/sections/listings/listing-carousel-section';
+import { logActivityLoadError } from '@/lib/activities/load-error';
 import { fetchActivitySearch } from '@/lib/activities/search-client';
 import {
   filtersToApiParams,
@@ -57,7 +58,8 @@ export function DiscoveryHomeSection({ locale, copy }: DiscoveryHomeSectionProps
           setListings(items);
         }
       })
-      .catch(() => {
+      .catch((error: unknown) => {
+        logActivityLoadError('discovery home', error);
         if (!cancelled) {
           setErrorMessage(copy.errorLabel);
           setListings([]);

--- a/apps/public_www/src/components/sections/home-wizard/home-wizard-section.tsx
+++ b/apps/public_www/src/components/sections/home-wizard/home-wizard-section.tsx
@@ -8,6 +8,7 @@ import {
   labelForLocale,
 } from '@/lib/home-wizard/choices';
 import { filterWizardResults } from '@/lib/home-wizard/filter-results';
+import { logActivityLoadError } from '@/lib/activities/load-error';
 import {
   fetchActivitiesForWizard,
   type ActivitySearchResult,
@@ -99,7 +100,8 @@ export function HomeWizardSection({ locale, copy }: HomeWizardSectionProps) {
           categoryIds,
         });
         setPrefetchedItems(response.items);
-      } catch {
+      } catch (error: unknown) {
+        logActivityLoadError('home wizard', error);
         setErrorMessage(copy.errorLabel);
       } finally {
         setIsLoading(false);

--- a/apps/public_www/src/lib/activities/load-error.ts
+++ b/apps/public_www/src/lib/activities/load-error.ts
@@ -1,0 +1,14 @@
+/**
+ * Logs activity fetch failures in development. Production keeps the generic UI
+ * copy only; env values must use static `process.env.NEXT_PUBLIC_*` access
+ * (see site-config.ts) so Next.js inlines them in the client bundle.
+ */
+export function logActivityLoadError(
+  context: string,
+  error: unknown,
+): void {
+  if (process.env.NODE_ENV !== 'development') {
+    return;
+  }
+  console.error(`[activities] ${context}`, error);
+}

--- a/apps/public_www/src/lib/site-config.ts
+++ b/apps/public_www/src/lib/site-config.ts
@@ -27,25 +27,27 @@ export interface PublicSiteConfig {
   readonly instagramUrl?: string;
 }
 
-function readPublicEnv(name: string): string {
-  return (process.env[name] ?? '').trim();
+function trimEnv(value: string | undefined): string {
+  return (value ?? '').trim();
 }
 
-function readBooleanEnv(name: string): boolean {
-  const raw = readPublicEnv(name).toLowerCase();
+function readBooleanEnv(value: string | undefined): boolean {
+  const raw = trimEnv(value).toLowerCase();
   return raw === 'true' || raw === '1' || raw === 'yes';
 }
 
 export function getSiteConfig(): SiteConfig {
   return {
-    siteOrigin: readPublicEnv('NEXT_PUBLIC_SITE_ORIGIN'),
-    siteName: readPublicEnv('NEXT_PUBLIC_SITE_NAME'),
-    siteTagline: readPublicEnv('NEXT_PUBLIC_SITE_TAGLINE'),
-    stagingBadgeEnabled: readBooleanEnv('NEXT_PUBLIC_STAGING_BADGE_ENABLED'),
+    siteOrigin: trimEnv(process.env.NEXT_PUBLIC_SITE_ORIGIN),
+    siteName: trimEnv(process.env.NEXT_PUBLIC_SITE_NAME),
+    siteTagline: trimEnv(process.env.NEXT_PUBLIC_SITE_TAGLINE),
+    stagingBadgeEnabled: readBooleanEnv(
+      process.env.NEXT_PUBLIC_STAGING_BADGE_ENABLED,
+    ),
     contact: {
-      email: readPublicEnv('NEXT_PUBLIC_EMAIL'),
-      whatsappUrl: readPublicEnv('NEXT_PUBLIC_WHATSAPP_URL'),
-      instagramUrl: readPublicEnv('NEXT_PUBLIC_INSTAGRAM_URL'),
+      email: trimEnv(process.env.NEXT_PUBLIC_EMAIL),
+      whatsappUrl: trimEnv(process.env.NEXT_PUBLIC_WHATSAPP_URL),
+      instagramUrl: trimEnv(process.env.NEXT_PUBLIC_INSTAGRAM_URL),
     },
     search: getSearchConfig(),
   };
@@ -53,14 +55,14 @@ export function getSiteConfig(): SiteConfig {
 
 export function getSearchConfig(): SearchConfig {
   const stagingSearchDataEnabled = readBooleanEnv(
-    'NEXT_PUBLIC_STAGING_SEARCH_DATA_ENABLED',
+    process.env.NEXT_PUBLIC_STAGING_SEARCH_DATA_ENABLED,
   );
-  const siteOrigin = readPublicEnv('NEXT_PUBLIC_SITE_ORIGIN').replace(
+  const siteOrigin = trimEnv(process.env.NEXT_PUBLIC_SITE_ORIGIN).replace(
     /\/$/,
     '',
   );
-  const explicitFixtureUrl = readPublicEnv(
-    'NEXT_PUBLIC_STAGING_SEARCH_FIXTURE_URL',
+  const explicitFixtureUrl = trimEnv(
+    process.env.NEXT_PUBLIC_STAGING_SEARCH_FIXTURE_URL,
   );
   const stagingSearchFixtureUrl =
     explicitFixtureUrl
@@ -71,14 +73,14 @@ export function getSearchConfig(): SearchConfig {
   return {
     stagingSearchDataEnabled,
     stagingSearchFixtureUrl,
-    apiBaseUrl: readPublicEnv('NEXT_PUBLIC_SEARCH_API_BASE_URL'),
-    apiKey: readPublicEnv('NEXT_PUBLIC_SEARCH_API_KEY'),
-    attestationToken: readPublicEnv('NEXT_PUBLIC_DEVICE_ATTESTATION_TOKEN'),
+    apiBaseUrl: trimEnv(process.env.NEXT_PUBLIC_SEARCH_API_BASE_URL),
+    apiKey: trimEnv(process.env.NEXT_PUBLIC_SEARCH_API_KEY),
+    attestationToken: trimEnv(process.env.NEXT_PUBLIC_DEVICE_ATTESTATION_TOKEN),
   };
 }
 
 export function getCopyrightYear(): number {
-  const raw = readPublicEnv('NEXT_PUBLIC_BUILD_YEAR');
+  const raw = trimEnv(process.env.NEXT_PUBLIC_BUILD_YEAR);
   const parsed = Number.parseInt(raw, 10);
   if (Number.isFinite(parsed) && parsed >= 2000 && parsed <= 2100) {
     return parsed;
@@ -88,9 +90,9 @@ export function getCopyrightYear(): number {
 }
 
 export function resolvePublicSiteConfig(): PublicSiteConfig {
-  const whatsappUrl = readPublicEnv('NEXT_PUBLIC_WHATSAPP_URL');
-  const contactEmail = readPublicEnv('NEXT_PUBLIC_EMAIL');
-  const instagramUrl = readPublicEnv('NEXT_PUBLIC_INSTAGRAM_URL');
+  const whatsappUrl = trimEnv(process.env.NEXT_PUBLIC_WHATSAPP_URL);
+  const contactEmail = trimEnv(process.env.NEXT_PUBLIC_EMAIL);
+  const instagramUrl = trimEnv(process.env.NEXT_PUBLIC_INSTAGRAM_URL);
 
   return {
     ...(whatsappUrl ? { whatsappUrl } : {}),

--- a/apps/public_www/tests/lib/site-config.test.ts
+++ b/apps/public_www/tests/lib/site-config.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { getCopyrightYear } from '@/lib/site-config';
+import { getCopyrightYear, getSearchConfig } from '@/lib/site-config';
 
 describe('getCopyrightYear', () => {
   const originalYear = process.env.NEXT_PUBLIC_BUILD_YEAR;
@@ -21,5 +21,68 @@ describe('getCopyrightYear', () => {
   it('falls back when env is missing or invalid', () => {
     delete process.env.NEXT_PUBLIC_BUILD_YEAR;
     expect(getCopyrightYear()).toBe(new Date().getFullYear());
+  });
+});
+
+describe('getSearchConfig', () => {
+  const envKeys = [
+    'NEXT_PUBLIC_STAGING_SEARCH_DATA_ENABLED',
+    'NEXT_PUBLIC_SITE_ORIGIN',
+    'NEXT_PUBLIC_STAGING_SEARCH_FIXTURE_URL',
+    'NEXT_PUBLIC_SEARCH_API_BASE_URL',
+    'NEXT_PUBLIC_SEARCH_API_KEY',
+    'NEXT_PUBLIC_DEVICE_ATTESTATION_TOKEN',
+  ] as const;
+
+  const original: Record<string, string | undefined> = {};
+
+  afterEach(() => {
+    for (const key of envKeys) {
+      if (original[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = original[key];
+      }
+    }
+  });
+
+  it('derives staging fixture URL from site origin when enabled', () => {
+    for (const key of envKeys) {
+      original[key] = process.env[key];
+    }
+    process.env.NEXT_PUBLIC_STAGING_SEARCH_DATA_ENABLED = 'true';
+    process.env.NEXT_PUBLIC_SITE_ORIGIN = 'http://localhost:3000/';
+    delete process.env.NEXT_PUBLIC_STAGING_SEARCH_FIXTURE_URL;
+    delete process.env.NEXT_PUBLIC_SEARCH_API_BASE_URL;
+
+    expect(getSearchConfig()).toEqual({
+      stagingSearchDataEnabled: true,
+      stagingSearchFixtureUrl:
+        'http://localhost:3000/fixtures/activity_search_staging.json',
+      apiBaseUrl: '',
+      apiKey: '',
+      attestationToken: '',
+    });
+  });
+
+  it('prefers explicit fixture URL and live API settings', () => {
+    for (const key of envKeys) {
+      original[key] = process.env[key];
+    }
+    process.env.NEXT_PUBLIC_STAGING_SEARCH_DATA_ENABLED = 'false';
+    process.env.NEXT_PUBLIC_SITE_ORIGIN = 'https://example.com';
+    process.env.NEXT_PUBLIC_STAGING_SEARCH_FIXTURE_URL =
+      'https://cdn.example.com/fixture.json';
+    process.env.NEXT_PUBLIC_SEARCH_API_BASE_URL = 'https://api.example.com';
+    process.env.NEXT_PUBLIC_SEARCH_API_KEY = 'test-key';
+    process.env.NEXT_PUBLIC_DEVICE_ATTESTATION_TOKEN = 'test-token';
+
+    expect(getSearchConfig()).toEqual({
+      stagingSearchDataEnabled: false,
+      stagingSearchFixtureUrl: 'https://cdn.example.com/fixture.json',
+      apiBaseUrl: 'https://api.example.com',
+      apiKey: 'test-key',
+      attestationToken: 'test-token',
+    });
   });
 });

--- a/docs/architecture/public-www.md
+++ b/docs/architecture/public-www.md
@@ -96,7 +96,10 @@ Source: [`apps/public_www`](../../apps/public_www).
   / Aurora. Optional override on staging:
   `NEXT_PUBLIC_STAGING_SEARCH_FIXTURE_URL`.
   CSP `connect-src` includes the API origin only when that URL is set at build
-  time (`scripts/inject-csp-meta.mjs`).
+  time (`scripts/inject-csp-meta.mjs`). `src/lib/site-config.ts` reads each
+  `NEXT_PUBLIC_*` via static `process.env.NEXT_PUBLIC_FOO` access so Next.js
+  inlines values in the client bundle (dynamic `process.env[name]` is empty in
+  the browser and breaks search).
 - **SEO:** `buildLocalizedMetadata` (canonical, hreflang). Optional GTM /
   Meta Pixel via `NEXT_PUBLIC_GTM_ID` / `NEXT_PUBLIC_META_PIXEL_ID` and
   host allow-lists; CSP `script-src` / `connect-src` extended at build time


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The discovery home page, search results, home wizard, and activity detail views showed **"Unable to load activities"** with no failed network requests. The underlying error was `Search API is not configured.`, thrown before any `fetch` because client-side search config was always empty.

`site-config.ts` read env vars via dynamic `process.env[name]`. Next.js only inlines **`process.env.NEXT_PUBLIC_FOO`** when the key is a static member access, so the browser bundle never received staging/API settings.

## Solution

- Refactor `site-config.ts` to use static `process.env.NEXT_PUBLIC_*` references (via a small `trimEnv` helper).
- Add `logActivityLoadError()` to log the real error in development (production UI unchanged).
- Extend `site-config` unit tests for staging fixture URL derivation.
- Document the static-access requirement in `docs/architecture/public-www.md`.

## Verification

- `npm run lint`, `npm run typecheck`, `npm test` in `apps/public_www`
- Headless Chromium: static export with matching `NEXT_PUBLIC_SITE_ORIGIN` loads the staging fixture and shows "Popular activities in Hong Kong" (no error UI)

## Local dev

For fixture-based search locally:

1. `git lfs pull`
2. `bash scripts/codegen/sync-activity-search-staging-fixture.sh public-www`
3. `.env.local` with `NEXT_PUBLIC_STAGING_SEARCH_DATA_ENABLED=true` and `NEXT_PUBLIC_SITE_ORIGIN` matching the dev server origin
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7221561-7980-400f-a75f-620dfcc963f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7221561-7980-400f-a75f-620dfcc963f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

