### PR TITLE
Apply modern-web-guidance performance and accessibility to public www

### DIFF
--- a/apps/public_www/src/app/globals.css
+++ b/apps/public_www/src/app/globals.css
@@ -37,6 +37,16 @@ body {
   scroll-snap-align: start;
 }
 
+.listing-card-deferred {
+  content-visibility: auto;
+  contain-intrinsic-size: auto none auto 360px;
+}
+
+.listing-section-deferred {
+  content-visibility: auto;
+  contain-intrinsic-size: auto none auto 420px;
+}
+
 .search-map-panel__canvas {
   position: relative;
   min-height: 320px;

--- a/apps/public_www/src/components/pages/activity-detail-page.tsx
+++ b/apps/public_www/src/components/pages/activity-detail-page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 
 import type { Locale, SiteContent } from '@/content';
 import { Button } from '@/components/shared/ui/button';
+import { preloadActivityImage } from '@/lib/activity-image-preload';
 import { logActivityLoadError } from '@/lib/activities/load-error';
 import { fetchActivityListingById } from '@/lib/activities/search-client';
 import {
@@ -17,6 +18,10 @@ import {
 } from '@/lib/activities/listing-utils';
 import { rememberViewedActivity } from '@/lib/activities/recent-storage';
 import type { ActivityListing } from '@/lib/activities/types';
+import {
+  LISTING_IMAGE_HEIGHT,
+  LISTING_IMAGE_WIDTH,
+} from '@/lib/listing-image';
 import { getSiteConfig } from '@/lib/site-config';
 
 interface ActivityDetailPageProps {
@@ -89,6 +94,15 @@ export function ActivityDetailPage({
     };
   }, [activityId, copy.errorLabel, copy.notFoundLabel]);
 
+  const imageUrl = listing ? listingImageUrl(listing) : null;
+
+  useEffect(() => {
+    if (!imageUrl) {
+      return undefined;
+    }
+    return preloadActivityImage(imageUrl);
+  }, [imageUrl]);
+
   const whatsappHref = useMemo(
     () => (listing ? buildWhatsappHref(contact.whatsappUrl, listing, locale) : null),
     [contact.whatsappUrl, listing, locale],
@@ -120,7 +134,6 @@ export function ActivityDetailPage({
   const region = regionLabelForListing(locale, listing);
   const schedule = formatScheduleSnippet(locale, listing.schedule.weeklyEntries);
   const price = formatListingPrice(locale, listing);
-  const imageUrl = listingImageUrl(listing);
 
   return (
     <article className="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
@@ -130,6 +143,10 @@ export function ActivityDetailPage({
             <img
               src={imageUrl}
               alt={title}
+              width={LISTING_IMAGE_WIDTH}
+              height={LISTING_IMAGE_HEIGHT}
+              decoding="async"
+              fetchPriority="high"
               className="h-full w-full object-cover"
             />
           ) : (

--- a/apps/public_www/src/components/sections/discovery/discovery-home-section.tsx
+++ b/apps/public_www/src/components/sections/discovery/discovery-home-section.tsx
@@ -114,6 +114,68 @@ export function DiscoveryHomeSection({ locale, copy }: DiscoveryHomeSectionProps
     imageFallback: copy.imageFallbackLabel,
   };
 
+  const carouselSections = useMemo(() => {
+    const sections: Array<{
+      readonly key: string;
+      readonly title: string;
+      readonly listings: readonly ActivityListing[];
+      readonly isLoading: boolean;
+    }> = [];
+
+    if (recentListings.length > 0) {
+      sections.push({
+        key: 'recent-search',
+        title: copy.continueSearchingTitle,
+        listings: recentListings,
+        isLoading: false,
+      });
+    }
+
+    if (viewedListings.length > 0) {
+      sections.push({
+        key: 'recently-viewed',
+        title: copy.recentlyViewedTitle,
+        listings: viewedListings,
+        isLoading: false,
+      });
+    }
+
+    sections.push({
+      key: 'popular',
+      title: copy.popularTitle,
+      listings: popularListings,
+      isLoading,
+    });
+
+    for (const [regionKey, regionListings] of regionGroups.entries()) {
+      const region = homeWizardChoices.regions.find(
+        (entry) => entry.areaId === regionKey,
+      );
+      const title = region
+        ? `${copy.nearRegionTitle} ${labelForLocale(region.labels, locale)}`
+        : copy.nearRegionTitle;
+      sections.push({
+        key: `region-${regionKey}`,
+        title,
+        listings: regionListings.slice(0, 12),
+        isLoading,
+      });
+    }
+
+    return sections;
+  }, [
+    copy.continueSearchingTitle,
+    copy.nearRegionTitle,
+    copy.popularTitle,
+    copy.recentlyViewedTitle,
+    isLoading,
+    locale,
+    popularListings,
+    recentListings,
+    regionGroups,
+    viewedListings,
+  ]);
+
   if (errorMessage) {
     return (
       <p className="mx-auto max-w-3xl px-4 py-12 text-center text-red-700">
@@ -124,49 +186,18 @@ export function DiscoveryHomeSection({ locale, copy }: DiscoveryHomeSectionProps
 
   return (
     <div className="bg-white">
-      {recentListings.length > 0 ? (
+      {carouselSections.map((section, sectionIndex) => (
         <ListingCarouselSection
+          key={section.key}
           locale={locale}
-          title={copy.continueSearchingTitle}
-          listings={recentListings}
-          isLoading={false}
+          title={section.title}
+          listings={section.listings}
+          isLoading={section.isLoading}
+          sectionIndex={sectionIndex}
+          isPrimaryCarousel={sectionIndex === 0}
           labels={cardLabels}
         />
-      ) : null}
-      {viewedListings.length > 0 ? (
-        <ListingCarouselSection
-          locale={locale}
-          title={copy.recentlyViewedTitle}
-          listings={viewedListings}
-          isLoading={false}
-          labels={cardLabels}
-        />
-      ) : null}
-      <ListingCarouselSection
-        locale={locale}
-        title={copy.popularTitle}
-        listings={popularListings}
-        isLoading={isLoading}
-        labels={cardLabels}
-      />
-      {[...regionGroups.entries()].map(([regionKey, regionListings]) => {
-        const region = homeWizardChoices.regions.find(
-          (entry) => entry.areaId === regionKey,
-        );
-        const title = region
-          ? `${copy.nearRegionTitle} ${labelForLocale(region.labels, locale)}`
-          : copy.nearRegionTitle;
-        return (
-          <ListingCarouselSection
-            key={regionKey}
-            locale={locale}
-            title={title}
-            listings={regionListings.slice(0, 12)}
-            isLoading={isLoading}
-            labels={cardLabels}
-          />
-        );
-      })}
+      ))}
     </div>
   );
 }

--- a/apps/public_www/src/components/sections/listings/listing-card.tsx
+++ b/apps/public_www/src/components/sections/listings/listing-card.tsx
@@ -12,6 +12,10 @@ import {
   listingTitle,
   regionLabelForListing,
 } from '@/lib/activities/listing-utils';
+import {
+  LISTING_IMAGE_HEIGHT,
+  LISTING_IMAGE_WIDTH,
+} from '@/lib/listing-image';
 import { localizePath } from '@/lib/locale-routing';
 
 interface ListingCardProps {
@@ -20,6 +24,9 @@ interface ListingCardProps {
   readonly freeTrialLabel: string;
   readonly imageAltFallback: string;
   readonly layout?: 'carousel' | 'grid';
+  readonly imageLoading?: 'lazy' | 'eager';
+  readonly imageFetchPriority?: 'high' | 'low';
+  readonly deferRendering?: boolean;
 }
 
 export function ListingCard({
@@ -28,9 +35,13 @@ export function ListingCard({
   freeTrialLabel,
   imageAltFallback,
   layout = 'carousel',
+  imageLoading = 'lazy',
+  imageFetchPriority,
+  deferRendering = false,
 }: ListingCardProps) {
   const widthClassName =
     layout === 'grid' ? 'w-full' : 'w-[280px] shrink-0 sm:w-[300px]';
+  const deferClassName = deferRendering ? 'listing-card-deferred' : '';
   const href = `${localizePath('/activity', locale)}?id=${listing.activity.id}`;
   const imageUrl = listingImageUrl(listing);
   const title = listingTitle(locale, listing);
@@ -40,14 +51,22 @@ export function ListingCard({
   const price = formatListingPrice(locale, listing);
 
   return (
-    <article className={`listing-card ${widthClassName}`}>
+    <article
+      className={`listing-card ${widthClassName} ${deferClassName}`.trim()}
+    >
       <Link href={href} className="group block">
         <div className="relative aspect-[4/3] overflow-hidden rounded-xl bg-brand-100">
           {imageUrl ? (
             <img
               src={imageUrl}
               alt={title}
-              loading="lazy"
+              width={LISTING_IMAGE_WIDTH}
+              height={LISTING_IMAGE_HEIGHT}
+              loading={imageLoading}
+              decoding="async"
+              {...(imageFetchPriority
+                ? { fetchPriority: imageFetchPriority }
+                : {})}
               className="h-full w-full object-cover transition duration-300 group-hover:scale-105"
             />
           ) : (

--- a/apps/public_www/src/components/sections/listings/listing-carousel-section.tsx
+++ b/apps/public_www/src/components/sections/listings/listing-carousel-section.tsx
@@ -3,6 +3,10 @@
 import type { Locale } from '@/content';
 import { Carousel } from '@/components/shared/ui/carousel';
 import type { ActivityListing } from '@/lib/activities/types';
+import {
+  listingCardImageLoading,
+  shouldDeferListingSectionRender,
+} from '@/lib/listing-image';
 
 import { ListingCard } from './listing-card';
 import { ListingCardSkeleton } from './listing-card-skeleton';
@@ -12,6 +16,8 @@ interface ListingCarouselSectionProps {
   readonly title: string;
   readonly listings: readonly ActivityListing[];
   readonly isLoading: boolean;
+  readonly sectionIndex?: number;
+  readonly isPrimaryCarousel?: boolean;
   readonly labels: {
     readonly previous: string;
     readonly next: string;
@@ -25,10 +31,16 @@ export function ListingCarouselSection({
   title,
   listings,
   isLoading,
+  sectionIndex = 0,
+  isPrimaryCarousel = false,
   labels,
 }: ListingCarouselSectionProps) {
+  const sectionClassName = shouldDeferListingSectionRender(sectionIndex)
+    ? 'listing-section-deferred py-8'
+    : 'py-8';
+
   return (
-    <section className="py-8" data-section-id="listing-carousel">
+    <section className={sectionClassName} data-section-id="listing-carousel">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <h2 className="text-xl font-semibold text-ink-900 sm:text-2xl">
           {title}
@@ -43,15 +55,23 @@ export function ListingCarouselSection({
               ? Array.from({ length: 4 }).map((_, index) => (
                   <ListingCardSkeleton key={`skeleton-${index}`} />
                 ))
-              : listings.map((listing) => (
-                  <ListingCard
-                    key={listing.activity.id}
-                    locale={locale}
-                    listing={listing}
-                    freeTrialLabel={labels.freeTrial}
-                    imageAltFallback={labels.imageFallback}
-                  />
-                ))}
+              : listings.map((listing, cardIndex) => {
+                  const imageProps = listingCardImageLoading({
+                    cardIndex,
+                    isPrimaryCarousel,
+                  });
+                  return (
+                    <ListingCard
+                      key={listing.activity.id}
+                      locale={locale}
+                      listing={listing}
+                      freeTrialLabel={labels.freeTrial}
+                      imageAltFallback={labels.imageFallback}
+                      imageLoading={imageProps.imageLoading}
+                      imageFetchPriority={imageProps.imageFetchPriority}
+                    />
+                  );
+                })}
           </Carousel>
         </div>
       </div>

--- a/apps/public_www/src/components/sections/listings/listing-grid.tsx
+++ b/apps/public_www/src/components/sections/listings/listing-grid.tsx
@@ -2,6 +2,7 @@
 
 import type { Locale } from '@/content';
 import type { ActivityListing } from '@/lib/activities/types';
+import { shouldDeferListingCardRender } from '@/lib/listing-image';
 
 import { ListingCard } from './listing-card';
 import { ListingCardSkeleton } from './listing-card-skeleton';
@@ -43,7 +44,7 @@ export function ListingGrid({
 
   return (
     <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-      {listings.map((listing) => (
+      {listings.map((listing, cardIndex) => (
         <ListingCard
           key={listing.activity.id}
           locale={locale}
@@ -51,6 +52,7 @@ export function ListingGrid({
           layout="grid"
           freeTrialLabel={labels.freeTrial}
           imageAltFallback={labels.imageFallback}
+          deferRendering={shouldDeferListingCardRender(cardIndex)}
         />
       ))}
     </div>

--- a/apps/public_www/src/components/sections/navbar-mobile-menu.tsx
+++ b/apps/public_www/src/components/sections/navbar-mobile-menu.tsx
@@ -11,6 +11,11 @@ import {
 } from 'react';
 
 import type { Locale, NavbarContent } from '@/content';
+import {
+  getFocusableElements,
+  handleFocusTrapKeyDown,
+  setInertOnElements,
+} from '@/lib/focus-management';
 import { localizeHref } from '@/lib/locale-routing';
 
 interface NavbarMobileMenuProps {
@@ -18,13 +23,8 @@ interface NavbarMobileMenuProps {
   readonly content: NavbarContent;
 }
 
-function getFocusableElements(container: HTMLElement): HTMLElement[] {
-  return Array.from(
-    container.querySelectorAll<HTMLElement>(
-      'a[href], button:not([disabled])',
-    ),
-  );
-}
+const SCROLL_LOCK_CLASS = 'navbar-mobile-menu-scroll-lock';
+const INERT_TARGET_IDS = ['main-content', 'contact'] as const;
 
 export function NavbarMobileMenu({ locale, content }: NavbarMobileMenuProps) {
   const [isOpen, setIsOpen] = useState(false);
@@ -45,21 +45,9 @@ export function NavbarMobileMenu({ locale, content }: NavbarMobileMenuProps) {
       return;
     }
 
-    const scrollLockClass = 'navbar-mobile-menu-scroll-lock';
-    const hadScrollLock = document.body.classList.contains(scrollLockClass);
-    document.body.classList.add(scrollLockClass);
-
-    const main = document.getElementById('main-content');
-    const footer = document.getElementById('contact');
-    const inertTargets = [main, footer].filter(
-      (element): element is HTMLElement => element instanceof HTMLElement,
-    );
-    const hadInert = inertTargets.map((element) =>
-      element.hasAttribute('inert'),
-    );
-    inertTargets.forEach((element) => {
-      element.setAttribute('inert', '');
-    });
+    const hadScrollLock = document.body.classList.contains(SCROLL_LOCK_CLASS);
+    document.body.classList.add(SCROLL_LOCK_CLASS);
+    const releaseInert = setInertOnElements(INERT_TARGET_IDS, true);
 
     const firstLink = panelRef.current?.querySelector<HTMLElement>('a[href]');
     firstLink?.focus();
@@ -71,25 +59,8 @@ export function NavbarMobileMenu({ locale, content }: NavbarMobileMenuProps) {
         return;
       }
 
-      if (event.key !== 'Tab' || !panelRef.current) {
-        return;
-      }
-
-      const focusables = getFocusableElements(panelRef.current);
-      if (focusables.length === 0) {
-        return;
-      }
-
-      const first = focusables[0];
-      const last = focusables[focusables.length - 1];
-      const active = document.activeElement;
-
-      if (event.shiftKey && active === first) {
-        event.preventDefault();
-        last.focus();
-      } else if (!event.shiftKey && active === last) {
-        event.preventDefault();
-        first.focus();
+      if (panelRef.current) {
+        handleFocusTrapKeyDown(event, panelRef.current);
       }
     };
 
@@ -97,15 +68,9 @@ export function NavbarMobileMenu({ locale, content }: NavbarMobileMenuProps) {
 
     return () => {
       if (!hadScrollLock) {
-        document.body.classList.remove(scrollLockClass);
+        document.body.classList.remove(SCROLL_LOCK_CLASS);
       }
-      inertTargets.forEach((element, index) => {
-        if (hadInert[index]) {
-          element.setAttribute('inert', '');
-        } else {
-          element.removeAttribute('inert');
-        }
-      });
+      releaseInert();
       document.removeEventListener('keydown', onKeyDown);
     };
   }, [isOpen, closeMenu]);

--- a/apps/public_www/src/components/sections/navbar.tsx
+++ b/apps/public_www/src/components/sections/navbar.tsx
@@ -56,7 +56,7 @@ export function Navbar({ locale, content }: NavbarProps) {
             className="hidden border-t border-brand-50 pb-3 pt-2 lg:block"
             aria-label="Main"
           >
-            <ul className="flex flex-wrap items-center gap-1">
+            <ul role="list" className="flex flex-wrap items-center gap-1">
               {content.menuItems.map((item) => (
                 <li key={item.href}>
                   <Link

--- a/apps/public_www/src/components/shared/analytics-resource-hints.tsx
+++ b/apps/public_www/src/components/shared/analytics-resource-hints.tsx
@@ -13,17 +13,9 @@ export function AnalyticsResourceHints() {
 
   return (
     <>
-      {hasGtm ? (
-        <>
-          <link rel="preconnect" href={GTM_ORIGIN} />
-          <link rel="dns-prefetch" href={GTM_ORIGIN} />
-        </>
-      ) : null}
+      {hasGtm ? <link rel="preconnect" href={GTM_ORIGIN} /> : null}
       {hasMetaPixel ? (
-        <>
-          <link rel="preconnect" href={META_PIXEL_ORIGIN} />
-          <link rel="dns-prefetch" href={META_PIXEL_ORIGIN} />
-        </>
+        <link rel="preconnect" href={META_PIXEL_ORIGIN} />
       ) : null}
     </>
   );

--- a/apps/public_www/src/components/shared/ui/modal.tsx
+++ b/apps/public_www/src/components/shared/ui/modal.tsx
@@ -3,6 +3,12 @@
 import type { ReactNode } from 'react';
 import { useEffect, useId, useRef } from 'react';
 
+import {
+  getFocusableElements,
+  handleFocusTrapKeyDown,
+  setInertOnElements,
+} from '@/lib/focus-management';
+
 interface ModalProps {
   readonly isOpen: boolean;
   readonly title: string;
@@ -10,28 +16,56 @@ interface ModalProps {
   readonly children: ReactNode;
 }
 
+const SCROLL_LOCK_CLASS = 'navbar-mobile-menu-scroll-lock';
+const INERT_TARGET_IDS = ['main-content', 'contact'] as const;
+
 export function Modal({ isOpen, title, onClose, children }: ModalProps) {
   const titleId = useId();
   const panelRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<Element | null>(null);
 
   useEffect(() => {
     if (!isOpen) {
       return;
     }
 
-    const scrollLockClass = 'navbar-mobile-menu-scroll-lock';
-    document.body.classList.add(scrollLockClass);
+    triggerRef.current = document.activeElement;
+
+    const hadScrollLock = document.body.classList.contains(SCROLL_LOCK_CLASS);
+    document.body.classList.add(SCROLL_LOCK_CLASS);
+    const releaseInert = setInertOnElements(INERT_TARGET_IDS, true);
+
+    const contentRoot = panelRef.current?.querySelector<HTMLElement>(
+      '[data-modal-body]',
+    );
+    const focusTarget = contentRoot
+      ? getFocusableElements(contentRoot)[0]
+      : panelRef.current
+        ? getFocusableElements(panelRef.current)[0]
+        : undefined;
+    focusTarget?.focus();
 
     function handleKeyDown(event: KeyboardEvent) {
       if (event.key === 'Escape') {
         onClose();
+        return;
+      }
+
+      if (panelRef.current) {
+        handleFocusTrapKeyDown(event, panelRef.current);
       }
     }
 
     document.addEventListener('keydown', handleKeyDown);
     return () => {
-      document.body.classList.remove(scrollLockClass);
+      if (!hadScrollLock) {
+        document.body.classList.remove(SCROLL_LOCK_CLASS);
+      }
+      releaseInert();
       document.removeEventListener('keydown', handleKeyDown);
+      if (triggerRef.current instanceof HTMLElement) {
+        triggerRef.current.focus();
+      }
     };
   }, [isOpen, onClose]);
 
@@ -67,7 +101,9 @@ export function Modal({ isOpen, title, onClose, children }: ModalProps) {
             ×
           </button>
         </div>
-        <div className="overflow-y-auto px-4 py-4">{children}</div>
+        <div data-modal-body className="overflow-y-auto px-4 py-4">
+          {children}
+        </div>
       </div>
     </div>
   );

--- a/apps/public_www/src/lib/activities/search-client.ts
+++ b/apps/public_www/src/lib/activities/search-client.ts
@@ -104,8 +104,13 @@ function mapListing(item: {
   };
 }
 
+interface FetchActivitySearchOptions {
+  readonly highPriority?: boolean;
+}
+
 export async function fetchActivitySearch(
   params: ActivitySearchParams,
+  options?: FetchActivitySearchOptions,
 ): Promise<ActivitySearchResponse> {
   const config = getSearchConfig();
   if (config.stagingSearchDataEnabled) {
@@ -143,7 +148,10 @@ export async function fetchActivitySearch(
     headers['x-device-attestation'] = config.attestationToken;
   }
 
-  const response = await fetch(url.toString(), { headers });
+  const response = await fetch(url.toString(), {
+    headers,
+    ...(options?.highPriority ? { priority: 'high' as RequestPriority } : {}),
+  });
   if (!response.ok) {
     throw new Error(`Search failed with status ${response.status}`);
   }
@@ -166,9 +174,12 @@ export async function fetchActivitySearch(
 export async function fetchActivityListingById(
   activityId: string,
 ): Promise<ActivityListing | null> {
-  const response = await fetchActivitySearch({
-    activityId,
-    limit: 1,
-  });
+  const response = await fetchActivitySearch(
+    {
+      activityId,
+      limit: 1,
+    },
+    { highPriority: true },
+  );
   return response.items[0] ?? null;
 }

--- a/apps/public_www/src/lib/activity-image-preload.ts
+++ b/apps/public_www/src/lib/activity-image-preload.ts
@@ -1,0 +1,12 @@
+export function preloadActivityImage(imageUrl: string): () => void {
+  const link = document.createElement('link');
+  link.rel = 'preload';
+  link.as = 'image';
+  link.href = imageUrl;
+  link.setAttribute('fetchpriority', 'high');
+  document.head.appendChild(link);
+
+  return () => {
+    link.remove();
+  };
+}

--- a/apps/public_www/src/lib/focus-management.ts
+++ b/apps/public_www/src/lib/focus-management.ts
@@ -1,0 +1,62 @@
+export function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), input:not([disabled]), ' +
+        'select:not([disabled]), textarea:not([disabled]), ' +
+        '[tabindex]:not([tabindex="-1"])',
+    ),
+  );
+}
+
+export function setInertOnElements(
+  elementIds: readonly string[],
+  inert: boolean,
+): () => void {
+  const targets = elementIds
+    .map((id) => document.getElementById(id))
+    .filter((element): element is HTMLElement => element instanceof HTMLElement);
+
+  const hadInert = targets.map((element) => element.hasAttribute('inert'));
+
+  if (inert) {
+    targets.forEach((element) => {
+      element.setAttribute('inert', '');
+    });
+  }
+
+  return () => {
+    targets.forEach((element, index) => {
+      if (hadInert[index]) {
+        element.setAttribute('inert', '');
+      } else {
+        element.removeAttribute('inert');
+      }
+    });
+  };
+}
+
+export function handleFocusTrapKeyDown(
+  event: KeyboardEvent,
+  container: HTMLElement,
+): void {
+  if (event.key !== 'Tab') {
+    return;
+  }
+
+  const focusables = getFocusableElements(container);
+  if (focusables.length === 0) {
+    return;
+  }
+
+  const first = focusables[0];
+  const last = focusables[focusables.length - 1];
+  const active = document.activeElement;
+
+  if (event.shiftKey && active === first) {
+    event.preventDefault();
+    last.focus();
+  } else if (!event.shiftKey && active === last) {
+    event.preventDefault();
+    first.focus();
+  }
+}

--- a/apps/public_www/src/lib/listing-image.ts
+++ b/apps/public_www/src/lib/listing-image.ts
@@ -1,0 +1,42 @@
+/** Intrinsic dimensions for 4:3 listing thumbnails (CLS + decode hints). */
+export const LISTING_IMAGE_WIDTH = 400;
+export const LISTING_IMAGE_HEIGHT = 300;
+
+export interface ListingCardImageLoadingOptions {
+  readonly cardIndex: number;
+  readonly isPrimaryCarousel: boolean;
+}
+
+export interface ListingCardImageLoadingResult {
+  readonly imageLoading: 'lazy' | 'eager';
+  readonly imageFetchPriority?: 'high' | 'low';
+}
+
+export function listingCardImageLoading({
+  cardIndex,
+  isPrimaryCarousel,
+}: ListingCardImageLoadingOptions): ListingCardImageLoadingResult {
+  if (isPrimaryCarousel && cardIndex === 0) {
+    return { imageLoading: 'eager', imageFetchPriority: 'high' };
+  }
+
+  if (isPrimaryCarousel && cardIndex === 1) {
+    return { imageLoading: 'eager' };
+  }
+
+  if (isPrimaryCarousel && cardIndex >= 2) {
+    return { imageLoading: 'lazy', imageFetchPriority: 'low' };
+  }
+
+  return { imageLoading: 'lazy' };
+}
+
+export function shouldDeferListingCardRender(cardIndex: number): boolean {
+  return cardIndex >= 4;
+}
+
+export function shouldDeferListingSectionRender(
+  sectionIndex: number,
+): boolean {
+  return sectionIndex >= 1;
+}

--- a/apps/public_www/tests/components/modal.test.tsx
+++ b/apps/public_www/tests/components/modal.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Modal } from '@/components/shared/ui/modal';
+
+describe('Modal', () => {
+  it('inerts page content and focuses the first field in the body', () => {
+    render(
+      <>
+        <main id="main-content">
+          <button type="button">Outside</button>
+        </main>
+        <footer id="contact">Footer</footer>
+        <Modal isOpen title="Search filters" onClose={vi.fn()}>
+          <button type="button">First field</button>
+          <button type="button">Second field</button>
+        </Modal>
+      </>,
+    );
+
+    const main = document.getElementById('main-content');
+    expect(main?.hasAttribute('inert')).toBe(true);
+    expect(document.getElementById('contact')?.hasAttribute('inert')).toBe(
+      true,
+    );
+    expect(document.body.classList.contains('navbar-mobile-menu-scroll-lock'))
+      .toBe(true);
+
+    expect(document.activeElement).toBe(
+      screen.getByRole('button', { name: 'First field' }),
+    );
+  });
+});

--- a/apps/public_www/tests/lib/activity-image-preload.test.ts
+++ b/apps/public_www/tests/lib/activity-image-preload.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { preloadActivityImage } from '@/lib/activity-image-preload';
+
+describe('preloadActivityImage', () => {
+  afterEach(() => {
+    document.head
+      .querySelectorAll('link[rel="preload"]')
+      .forEach((node) => node.remove());
+  });
+
+  it('inserts and removes a high-priority image preload link', () => {
+    const cleanup = preloadActivityImage('https://example.com/hero.jpg');
+    const link = document.head.querySelector<HTMLLinkElement>(
+      'link[rel="preload"]',
+    );
+    expect(link?.getAttribute('href')).toBe('https://example.com/hero.jpg');
+    expect(link?.getAttribute('fetchpriority')).toBe('high');
+
+    cleanup();
+    expect(document.head.querySelector('link[rel="preload"]')).toBeNull();
+  });
+});

--- a/apps/public_www/tests/lib/focus-management.test.ts
+++ b/apps/public_www/tests/lib/focus-management.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { handleFocusTrapKeyDown } from '@/lib/focus-management';
+
+describe('handleFocusTrapKeyDown', () => {
+  it('wraps focus from first to last on Shift+Tab', () => {
+    const container = document.createElement('div');
+    const first = document.createElement('button');
+    first.textContent = 'First';
+    const last = document.createElement('button');
+    last.textContent = 'Last';
+    container.append(first, last);
+    document.body.append(container);
+    first.focus();
+
+    handleFocusTrapKeyDown(
+      new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true }),
+      container,
+    );
+
+    expect(document.activeElement).toBe(last);
+    container.remove();
+  });
+});

--- a/apps/public_www/tests/lib/listing-image.test.ts
+++ b/apps/public_www/tests/lib/listing-image.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  listingCardImageLoading,
+  shouldDeferListingCardRender,
+  shouldDeferListingSectionRender,
+} from '@/lib/listing-image';
+
+describe('listingCardImageLoading', () => {
+  it('prioritizes the first card in the primary carousel', () => {
+    expect(
+      listingCardImageLoading({ cardIndex: 0, isPrimaryCarousel: true }),
+    ).toEqual({ imageLoading: 'eager', imageFetchPriority: 'high' });
+  });
+
+  it('eager-loads the second primary carousel card without low priority', () => {
+    expect(
+      listingCardImageLoading({ cardIndex: 1, isPrimaryCarousel: true }),
+    ).toEqual({ imageLoading: 'eager' });
+  });
+
+  it('deprioritizes hidden primary carousel slides', () => {
+    expect(
+      listingCardImageLoading({ cardIndex: 2, isPrimaryCarousel: true }),
+    ).toEqual({ imageLoading: 'lazy', imageFetchPriority: 'low' });
+  });
+
+  it('lazy-loads non-primary carousel cards', () => {
+    expect(
+      listingCardImageLoading({ cardIndex: 0, isPrimaryCarousel: false }),
+    ).toEqual({ imageLoading: 'lazy' });
+  });
+});
+
+describe('defer rendering helpers', () => {
+  it('defers grid cards from the second row onward', () => {
+    expect(shouldDeferListingCardRender(3)).toBe(false);
+    expect(shouldDeferListingCardRender(4)).toBe(true);
+  });
+
+  it('defers carousel sections after the first', () => {
+    expect(shouldDeferListingSectionRender(0)).toBe(false);
+    expect(shouldDeferListingSectionRender(1)).toBe(true);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the modern-web-guidance audit recommendations for `apps/public_www`: image loading priority, deferred rendering, modal accessibility, and leaner analytics hints.

## Changes

### Performance
- **Listing images**: intrinsic `400×300` dimensions, `decoding="async"`, and context-aware `loading` / `fetchPriority` (primary carousel first card = eager + high; hidden slides = low; grids stay lazy-only).
- **Deferred paint**: `content-visibility: auto` with `contain-intrinsic-size` for off-screen carousel sections and search grid cards (index ≥ 4).
- **Activity detail**: `fetchpriority="high"` on hero image, `priority: 'high'` on listing API fetch, and `<link rel="preload">` once the image URL is known.

### Accessibility
- **Modal**: focus trap, `inert` on `#main-content` / `#contact`, initial focus on first body field, focus restore on close.
- **Shared utilities**: `focus-management.ts` reused by modal and mobile nav.
- **Navbar**: `role="list"` on flex menu list (Safari list-semantics caveat).

### Resource hints
- Removed redundant `dns-prefetch` where `preconnect` is already present for GTM and Meta Pixel.

## Tests

- Added unit tests for `listing-image`, `focus-management`, `activity-image-preload`, and `Modal`.
- `npm run lint`, `npm run typecheck`, and Vitest pass (staging fixture tests still require Git LFS locally).

## Not in scope

- Migrating overlays to native `<dialog>` / Invoker Commands (would need polyfill policy).
- `/activity/[id]` static routes for build-time hero HTML (larger URL/export change).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79412c38-5a46-4588-ac68-623ac132d26c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79412c38-5a46-4588-ac68-623ac132d26c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

