### PR TITLE
Google Maps split search and listing card mini-maps

### DIFF
--- a/.github/workflows/deploy-public-www.yml
+++ b/.github/workflows/deploy-public-www.yml
@@ -85,6 +85,7 @@ jobs:
           # Staging Environment var only (ignored on production promote).
           NEXT_PUBLIC_STAGING_SEARCH_DATA_ENABLED: ${{ vars.STAGING_SEARCH_DATA_ENABLED || 'true' }}
           NEXT_PUBLIC_STAGING_SEARCH_FIXTURE_URL: ${{ vars.NEXT_PUBLIC_STAGING_SEARCH_FIXTURE_URL }}
+          NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: ${{ vars.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY }}
 
       - name: Configure AWS credentials
         if: ${{ vars.AWS_ACCOUNT_ID != '' && vars.AWS_REGION != '' }}

--- a/.github/workflows/promote-public-www.yml
+++ b/.github/workflows/promote-public-www.yml
@@ -131,6 +131,7 @@ jobs:
           NEXT_PUBLIC_INSTAGRAM_URL: ${{ vars.NEXT_PUBLIC_INSTAGRAM_URL }}
           NEXT_PUBLIC_STAGING_BADGE_ENABLED: 'false'
           NEXT_PUBLIC_STAGING_SEARCH_DATA_ENABLED: 'false'
+          NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: ${{ vars.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY }}
 
       - name: Promote release or enable maintenance mode
         run: bash 'scripts/deploy/deploy-public-www.sh'

--- a/apps/public_www/.env.example
+++ b/apps/public_www/.env.example
@@ -29,6 +29,10 @@ NEXT_PUBLIC_STAGING_BADGE_ENABLED=false
 NEXT_PUBLIC_STAGING_SEARCH_DATA_ENABLED=false
 NEXT_PUBLIC_STAGING_SEARCH_FIXTURE_URL=
 
+# Google Maps (optional). Enables the split search map view and mini-maps on
+# listing cards (Maps JavaScript API + Static Maps API).
+NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=
+
 # Analytics (optional). Scripts load only on allow-listed hosts (defaults to
 # the site hostname derived from NEXT_PUBLIC_SITE_ORIGIN).
 NEXT_PUBLIC_GTM_ID=

--- a/apps/public_www/scripts/inject-csp-meta.mjs
+++ b/apps/public_www/scripts/inject-csp-meta.mjs
@@ -26,6 +26,11 @@ const GTM_CONNECT_ORIGINS = [
 ];
 const META_PIXEL_SCRIPT_ORIGINS = ['https://connect.facebook.net'];
 const META_PIXEL_CONNECT_ORIGINS = ['https://www.facebook.com'];
+const GOOGLE_MAPS_SCRIPT_ORIGINS = ['https://maps.googleapis.com'];
+const GOOGLE_MAPS_CONNECT_ORIGINS = [
+  'https://maps.googleapis.com',
+  'https://maps.gstatic.com',
+];
 
 /**
  * @param {string[]} inlineScriptHashes
@@ -55,6 +60,14 @@ function buildCspDirectives(inlineScriptHashes) {
   if (hasMetaPixel) {
     scriptSources.push(...META_PIXEL_SCRIPT_ORIGINS);
     connectSources.push(...META_PIXEL_CONNECT_ORIGINS);
+  }
+
+  const hasGoogleMaps = Boolean(
+    process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY?.trim(),
+  );
+  if (hasGoogleMaps) {
+    scriptSources.push(...GOOGLE_MAPS_SCRIPT_ORIGINS);
+    connectSources.push(...GOOGLE_MAPS_CONNECT_ORIGINS);
   }
 
   return [

--- a/apps/public_www/src/app/globals.css
+++ b/apps/public_www/src/app/globals.css
@@ -64,6 +64,24 @@ body {
   transform: translate(-50%, -100%);
 }
 
+.activity-google-map {
+  min-height: 280px;
+  width: 100%;
+  background-color: var(--color-brand-50);
+}
+
+.search-map-split-layout__map .activity-google-map {
+  min-height: 100%;
+}
+
+.listing-card-mini-map {
+  background: linear-gradient(
+    180deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.85) 35%
+  );
+}
+
 a {
   color: inherit;
   text-decoration: none;

--- a/apps/public_www/src/components/pages/search-results-page.tsx
+++ b/apps/public_www/src/components/pages/search-results-page.tsx
@@ -1,21 +1,26 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 import type { Locale, SiteContent } from '@/content';
 import { FilterChipRow } from '@/components/sections/search/filter-chip-row';
-import { SearchMapPanel } from '@/components/sections/search/search-map-panel';
+import { SearchMapSplitLayout } from '@/components/sections/search/search-map-split-layout';
 import { ListingGrid } from '@/components/sections/listings/listing-grid';
 import { useSearchContext } from '@/components/shared/search/search-context';
 import { Chip } from '@/components/shared/ui/chip';
-import { logActivityLoadError } from '@/lib/activities/load-error';
 import { fetchActivitySearch } from '@/lib/activities/search-client';
+import { buildMapSearchHref } from '@/lib/activities/map-search-url';
 import {
+  buildSearchQueryString,
   filtersToApiParams,
   parseSearchFiltersFromQuery,
+  parseSearchViewMode,
 } from '@/lib/activities/search-params';
 import { matchesTextQuery } from '@/lib/activities/listing-utils';
+import { listingsWithCoordinates } from '@/lib/google-maps/coordinates';
+import { isGoogleMapsEnabled } from '@/lib/google-maps/config';
+import { localizePath } from '@/lib/locale-routing';
 import type { ActivityListing } from '@/lib/activities/types';
 
 interface SearchResultsPageProps {
@@ -24,12 +29,12 @@ interface SearchResultsPageProps {
 }
 
 export function SearchResultsPage({ locale, copy }: SearchResultsPageProps) {
+  const router = useRouter();
   const searchParams = useSearchParams();
   const { filters, setFilters } = useSearchContext();
   const [listings, setListings] = useState<readonly ActivityListing[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [viewMode, setViewMode] = useState<'list' | 'map'>('list');
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [textQuery, setTextQuery] = useState(filters.textQuery);
 
@@ -37,6 +42,12 @@ export function SearchResultsPage({ locale, copy }: SearchResultsPageProps) {
     () => parseSearchFiltersFromQuery(searchParams),
     [searchParams],
   );
+  const urlViewMode = useMemo(
+    () => parseSearchViewMode(searchParams),
+    [searchParams],
+  );
+  const mapsEnabled = isGoogleMapsEnabled();
+  const showMapSplit = mapsEnabled && urlViewMode === 'map';
 
   useEffect(() => {
     setFilters(urlFilters);
@@ -56,8 +67,7 @@ export function SearchResultsPage({ locale, copy }: SearchResultsPageProps) {
         matchesTextQuery(listing, locale, urlFilters.textQuery),
       );
       setListings(filtered);
-    } catch (error: unknown) {
-      logActivityLoadError('search results', error);
+    } catch {
       setErrorMessage(copy.errorLabel);
       setListings([]);
     } finally {
@@ -78,25 +88,47 @@ export function SearchResultsPage({ locale, copy }: SearchResultsPageProps) {
     );
   }, [listings, locale, textQuery]);
 
+  useEffect(() => {
+    if (!showMapSplit || visibleListings.length === 0) {
+      return;
+    }
+    if (
+      selectedId &&
+      visibleListings.some((listing) => listing.activity.id === selectedId)
+    ) {
+      return;
+    }
+    const firstMappable = listingsWithCoordinates(visibleListings)[0];
+    setSelectedId(
+      firstMappable?.activity.id ?? visibleListings[0]?.activity.id ?? null,
+    );
+  }, [selectedId, showMapSplit, visibleListings]);
+
+  function navigateToListView() {
+    const query = buildSearchQueryString(urlFilters);
+    const path = localizePath('/search', locale);
+    router.push(query ? `${path}?${query}` : path);
+  }
+
+  function navigateToMapView() {
+    router.push(buildMapSearchHref(locale, urlFilters));
+  }
+
   return (
     <div className="bg-white">
       <FilterChipRow locale={locale} />
       <div className="border-b border-brand-100 bg-white">
         <div className="mx-auto flex max-w-7xl flex-wrap items-center gap-3 px-4 py-4 sm:px-6 lg:px-8">
-          <div className="flex gap-2">
-            <Chip
-              isSelected={viewMode === 'list'}
-              onClick={() => setViewMode('list')}
-            >
-              {copy.listViewLabel}
-            </Chip>
-            <Chip
-              isSelected={viewMode === 'map'}
-              onClick={() => setViewMode('map')}
-            >
-              {copy.mapViewLabel}
-            </Chip>
-          </div>
+          {mapsEnabled ? (
+            <div className="flex gap-2">
+              <Chip isSelected={!showMapSplit} onClick={navigateToListView}>
+                {copy.listViewLabel}
+              </Chip>
+              <Chip isSelected={showMapSplit} onClick={navigateToMapView}>
+                {copy.mapViewLabel}
+              </Chip>
+            </div>
+          ) : null}
           <label className="min-w-[220px] flex-1">
             <span className="sr-only">{copy.textFilterLabel}</span>
             <input
@@ -115,37 +147,22 @@ export function SearchResultsPage({ locale, copy }: SearchResultsPageProps) {
           </p>
         </div>
       </div>
-      <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-        {errorMessage ? (
-          <p className="mb-6 text-center text-red-700">{errorMessage}</p>
-        ) : null}
-        {viewMode === 'map' ? (
-          <div className="grid gap-6 lg:grid-cols-2">
-            <SearchMapPanel
-              locale={locale}
-              listings={visibleListings}
-              selectedId={selectedId}
-              onSelect={setSelectedId}
-              emptyLabel={copy.mapEmptyLabel}
-            />
-            <ListingGrid
-              locale={locale}
-              listings={
-                selectedId
-                  ? visibleListings.filter(
-                      (listing) => listing.activity.id === selectedId,
-                    )
-                  : visibleListings
-              }
-              isLoading={isLoading}
-              labels={{
-                freeTrial: copy.freeTrialLabel,
-                imageFallback: copy.imageFallbackLabel,
-                empty: copy.emptyLabel,
-              }}
-            />
-          </div>
-        ) : (
+      {errorMessage ? (
+        <p className="mx-auto max-w-7xl px-4 py-6 text-center text-red-700">
+          {errorMessage}
+        </p>
+      ) : null}
+      {showMapSplit ? (
+        <SearchMapSplitLayout
+          locale={locale}
+          copy={copy}
+          listings={visibleListings}
+          selectedId={selectedId}
+          onSelect={setSelectedId}
+          isLoading={isLoading}
+        />
+      ) : (
+        <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
           <ListingGrid
             locale={locale}
             listings={visibleListings}
@@ -153,11 +170,12 @@ export function SearchResultsPage({ locale, copy }: SearchResultsPageProps) {
             labels={{
               freeTrial: copy.freeTrialLabel,
               imageFallback: copy.imageFallbackLabel,
+              mapAlt: copy.mapAltLabel,
               empty: copy.emptyLabel,
             }}
           />
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/public_www/src/components/sections/discovery/discovery-home-section.tsx
+++ b/apps/public_www/src/components/sections/discovery/discovery-home-section.tsx
@@ -112,6 +112,7 @@ export function DiscoveryHomeSection({ locale, copy }: DiscoveryHomeSectionProps
     next: copy.carousel.nextLabel,
     freeTrial: copy.freeTrialLabel,
     imageFallback: copy.imageFallbackLabel,
+    mapAlt: copy.mapAltLabel,
   };
 
   const carouselSections = useMemo(() => {

--- a/apps/public_www/src/components/sections/listings/listing-card-mini-map.tsx
+++ b/apps/public_www/src/components/sections/listings/listing-card-mini-map.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import type { ActivityListing } from '@/lib/activities/types';
+import { listingCoordinate } from '@/lib/google-maps/coordinates';
+import {
+  getGoogleMapsConfig,
+  isGoogleMapsEnabled,
+} from '@/lib/google-maps/config';
+import { buildStaticMapUrl } from '@/lib/google-maps/static-map-url';
+import { listingTitle } from '@/lib/activities/listing-utils';
+import type { Locale } from '@/content';
+
+interface ListingCardMiniMapProps {
+  readonly locale: Locale;
+  readonly listing: ActivityListing;
+  readonly mapAltLabel: string;
+}
+
+export function ListingCardMiniMap({
+  locale,
+  listing,
+  mapAltLabel,
+}: ListingCardMiniMapProps) {
+  if (!isGoogleMapsEnabled()) {
+    return null;
+  }
+
+  const coordinate = listingCoordinate(listing);
+  if (!coordinate) {
+    return null;
+  }
+
+  const { apiKey } = getGoogleMapsConfig();
+  const mapUrl = buildStaticMapUrl({
+    apiKey,
+    coordinate,
+    variant: 'card',
+    zoom: 15,
+  });
+  const title = listingTitle(locale, listing);
+
+  return (
+    <div className="listing-card-mini-map pointer-events-none absolute inset-x-0 bottom-0 h-[38%] overflow-hidden rounded-b-xl border-t border-white/80">
+      <img
+        src={mapUrl}
+        alt={`${mapAltLabel}: ${title}`}
+        width={600}
+        height={200}
+        loading="lazy"
+        decoding="async"
+        className="h-full w-full object-cover"
+      />
+    </div>
+  );
+}

--- a/apps/public_www/src/components/sections/listings/listing-card.tsx
+++ b/apps/public_www/src/components/sections/listings/listing-card.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 
 import type { Locale } from '@/content';
 import type { ActivityListing } from '@/lib/activities/types';
+import { regionIdForListing } from '@/lib/activities/map-search-url';
 import {
   formatListingPrice,
   formatScheduleSnippet,
@@ -12,6 +13,9 @@ import {
   listingTitle,
   regionLabelForListing,
 } from '@/lib/activities/listing-utils';
+import { useSearchContext } from '@/components/shared/search/search-context';
+import { RegionMapLink } from '@/components/shared/search/region-map-link';
+import { ListingCardMiniMap } from '@/components/sections/listings/listing-card-mini-map';
 import {
   LISTING_IMAGE_HEIGHT,
   LISTING_IMAGE_WIDTH,
@@ -23,6 +27,7 @@ interface ListingCardProps {
   readonly listing: ActivityListing;
   readonly freeTrialLabel: string;
   readonly imageAltFallback: string;
+  readonly mapAltLabel: string;
   readonly layout?: 'carousel' | 'grid';
   readonly imageLoading?: 'lazy' | 'eager';
   readonly imageFetchPriority?: 'high' | 'low';
@@ -34,11 +39,13 @@ export function ListingCard({
   listing,
   freeTrialLabel,
   imageAltFallback,
+  mapAltLabel,
   layout = 'carousel',
   imageLoading = 'lazy',
   imageFetchPriority,
   deferRendering = false,
 }: ListingCardProps) {
+  const { filters } = useSearchContext();
   const widthClassName =
     layout === 'grid' ? 'w-full' : 'w-[280px] shrink-0 sm:w-[300px]';
   const deferClassName = deferRendering ? 'listing-card-deferred' : '';
@@ -47,6 +54,7 @@ export function ListingCard({
   const title = listingTitle(locale, listing);
   const orgName = listingOrgName(locale, listing);
   const region = regionLabelForListing(locale, listing);
+  const regionId = regionIdForListing(listing);
   const schedule = formatScheduleSnippet(locale, listing.schedule.weeklyEntries);
   const price = formatListingPrice(locale, listing);
 
@@ -79,13 +87,30 @@ export function ListingCard({
               {freeTrialLabel}
             </span>
           ) : null}
+          <ListingCardMiniMap
+            locale={locale}
+            listing={listing}
+            mapAltLabel={mapAltLabel}
+          />
         </div>
         <div className="mt-3 space-y-1">
           <h3 className="line-clamp-2 text-[15px] font-semibold text-ink-900">
             {title}
           </h3>
           <p className="text-sm text-ink-500">
-            {[orgName, region, schedule].filter(Boolean).join(' · ')}
+            {orgName}
+            {orgName && (region || schedule) ? ' · ' : ''}
+            {region && regionId ? (
+              <RegionMapLink
+                locale={locale}
+                label={region}
+                filters={filters}
+                regionId={regionId}
+              />
+            ) : (
+              region
+            )}
+            {schedule ? ` · ${schedule}` : ''}
           </p>
           <p className="text-sm font-semibold text-ink-900">
             <span>{price}</span>

--- a/apps/public_www/src/components/sections/listings/listing-carousel-section.tsx
+++ b/apps/public_www/src/components/sections/listings/listing-carousel-section.tsx
@@ -23,6 +23,7 @@ interface ListingCarouselSectionProps {
     readonly next: string;
     readonly freeTrial: string;
     readonly imageFallback: string;
+    readonly mapAlt: string;
   };
 }
 
@@ -67,6 +68,7 @@ export function ListingCarouselSection({
                       listing={listing}
                       freeTrialLabel={labels.freeTrial}
                       imageAltFallback={labels.imageFallback}
+                      mapAltLabel={labels.mapAlt}
                       imageLoading={imageProps.imageLoading}
                       imageFetchPriority={imageProps.imageFetchPriority}
                     />

--- a/apps/public_www/src/components/sections/listings/listing-grid.tsx
+++ b/apps/public_www/src/components/sections/listings/listing-grid.tsx
@@ -15,6 +15,7 @@ interface ListingGridProps {
     readonly freeTrial: string;
     readonly imageFallback: string;
     readonly empty: string;
+    readonly mapAlt: string;
   };
 }
 
@@ -52,6 +53,7 @@ export function ListingGrid({
           layout="grid"
           freeTrialLabel={labels.freeTrial}
           imageAltFallback={labels.imageFallback}
+          mapAltLabel={labels.mapAlt}
           deferRendering={shouldDeferListingCardRender(cardIndex)}
         />
       ))}

--- a/apps/public_www/src/components/sections/search/search-bar-compact.tsx
+++ b/apps/public_www/src/components/sections/search/search-bar-compact.tsx
@@ -1,12 +1,18 @@
 'use client';
 
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+
 import type { Locale } from '@/content';
 import { useSearchContext } from '@/components/shared/search/search-context';
+import { buildMapSearchHref } from '@/lib/activities/map-search-url';
 import { homeWizardChoices, labelForLocale } from '@/lib/home-wizard/choices';
 import {
   areaIdForRegion,
+  buildSearchQueryString,
   searchAgeForGroup,
 } from '@/lib/activities/search-params';
+import { localizePath } from '@/lib/locale-routing';
 
 interface SearchBarCompactProps {
   readonly locale: Locale;
@@ -18,6 +24,7 @@ interface SearchBarCompactProps {
     readonly anywhere: string;
     readonly anyAge: string;
     readonly anyType: string;
+    readonly openMapForAreaLabel: string;
   };
 }
 
@@ -46,6 +53,7 @@ function summarizeTypes(
 }
 
 export function SearchBarCompact({ locale, labels }: SearchBarCompactProps) {
+  const router = useRouter();
   const { filters, openSearch } = useSearchContext();
 
   const region = homeWizardChoices.regions.find(
@@ -66,39 +74,65 @@ export function SearchBarCompact({ locale, labels }: SearchBarCompactProps) {
 
   const hasArea = Boolean(areaIdForRegion(filters.regionId));
   const hasAge = Boolean(searchAgeForGroup(filters.ageGroupId));
+  const mapHref = buildMapSearchHref(locale, filters);
+  const searchHref = (() => {
+    const query = buildSearchQueryString(filters);
+    const path = localizePath('/search', locale);
+    return query ? `${path}?${query}` : path;
+  })();
+
+  function handleSearchNavigate() {
+    router.push(searchHref);
+  }
 
   return (
-    <button
-      type="button"
-      onClick={openSearch}
-      className="search-bar-compact flex w-full max-w-3xl items-center rounded-full border border-ink-900/15 bg-white py-1 pl-4 pr-1 shadow-sm transition hover:shadow-md"
-      aria-label={labels.search}
+    <div
+      className="search-bar-compact flex w-full max-w-3xl items-center rounded-full border border-ink-900/15 bg-white py-1 pl-4 pr-1 shadow-sm"
+      role="search"
     >
       <span className="hidden min-w-0 flex-1 grid-cols-3 divide-x divide-ink-900/10 md:grid">
-        <span className="truncate px-3 py-2 text-left">
+        <Link
+          href={mapHref}
+          className="truncate px-3 py-2 text-left transition hover:bg-brand-50"
+          aria-label={`${labels.openMapForAreaLabel}: ${whereLabel}`}
+          onClick={(event) => event.stopPropagation()}
+        >
           <span className="block text-xs font-semibold text-ink-900">
             {labels.where}
           </span>
-          <span className="block truncate text-sm text-ink-500">
+          <span className="block truncate text-sm text-brand-600">
             {whereLabel}
           </span>
-        </span>
-        <span className="truncate px-3 py-2 text-left">
+        </Link>
+        <button
+          type="button"
+          className="truncate px-3 py-2 text-left transition hover:bg-brand-50"
+          onClick={openSearch}
+        >
           <span className="block text-xs font-semibold text-ink-900">
             {labels.childAge}
           </span>
           <span className="block truncate text-sm text-ink-500">{ageLabel}</span>
-        </span>
-        <span className="truncate px-3 py-2 text-left">
+        </button>
+        <button
+          type="button"
+          className="truncate px-3 py-2 text-left transition hover:bg-brand-50"
+          onClick={openSearch}
+        >
           <span className="block text-xs font-semibold text-ink-900">
             {labels.activityTypes}
           </span>
           <span className="block truncate text-sm text-ink-500">
             {typesLabel}
           </span>
-        </span>
+        </button>
       </span>
-      <span className="min-w-0 flex-1 truncate px-2 py-2 text-left text-sm text-ink-700 md:hidden">
+      <button
+        type="button"
+        className="min-w-0 flex-1 truncate px-2 py-2 text-left text-sm text-ink-700 md:hidden"
+        onClick={openSearch}
+        aria-label={labels.search}
+      >
         {[whereLabel, ageLabel, typesLabel]
           .filter((value, index) => {
             if (index === 0) {
@@ -107,10 +141,15 @@ export function SearchBarCompact({ locale, labels }: SearchBarCompactProps) {
             return true;
           })
           .join(' · ')}
-      </span>
-      <span className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-accent-500 text-lg text-white">
+      </button>
+      <button
+        type="button"
+        className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-accent-500 text-lg text-white transition hover:bg-accent-600"
+        aria-label={labels.search}
+        onClick={handleSearchNavigate}
+      >
         ⌕
-      </span>
-    </button>
+      </button>
+    </div>
   );
 }

--- a/apps/public_www/src/components/sections/search/search-map-list-item.tsx
+++ b/apps/public_www/src/components/sections/search/search-map-list-item.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import Link from 'next/link';
+
+import type { Locale } from '@/content';
+import type { ActivityListing } from '@/lib/activities/types';
+import {
+  formatListingPrice,
+  listingImageUrl,
+  listingTitle,
+  regionLabelForListing,
+} from '@/lib/activities/listing-utils';
+import { localizePath } from '@/lib/locale-routing';
+import {
+  LISTING_IMAGE_HEIGHT,
+  LISTING_IMAGE_WIDTH,
+} from '@/lib/listing-image';
+
+interface SearchMapListItemProps {
+  readonly locale: Locale;
+  readonly listing: ActivityListing;
+  readonly isSelected: boolean;
+  readonly imageFallbackLabel: string;
+  readonly onSelect: () => void;
+}
+
+export function SearchMapListItem({
+  locale,
+  listing,
+  isSelected,
+  imageFallbackLabel,
+  onSelect,
+}: SearchMapListItemProps) {
+  const href = `${localizePath('/activity', locale)}?id=${listing.activity.id}`;
+  const imageUrl = listingImageUrl(listing);
+  const title = listingTitle(locale, listing);
+  const region = regionLabelForListing(locale, listing);
+  const price = formatListingPrice(locale, listing);
+
+  return (
+    <article
+      className={`search-map-list-item flex gap-3 rounded-xl border p-3 transition ${
+        isSelected
+          ? 'border-brand-500 bg-brand-50'
+          : 'border-brand-100 bg-white hover:border-brand-200'
+      }`}
+    >
+      <button
+        type="button"
+        className="flex min-w-0 flex-1 gap-3 text-left"
+        onClick={onSelect}
+      >
+        <div className="relative h-20 w-20 shrink-0 overflow-hidden rounded-lg bg-brand-100">
+          {imageUrl ? (
+            <img
+              src={imageUrl}
+              alt={title}
+              width={LISTING_IMAGE_WIDTH}
+              height={LISTING_IMAGE_HEIGHT}
+              loading="lazy"
+              decoding="async"
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <span className="flex h-full items-center justify-center px-1 text-center text-[10px] text-ink-500">
+              {imageFallbackLabel}
+            </span>
+          )}
+        </div>
+        <div className="min-w-0 flex-1">
+          <h3 className="line-clamp-2 text-sm font-semibold text-ink-900">
+            {title}
+          </h3>
+          {region ? (
+            <p className="mt-1 text-xs text-ink-500">{region}</p>
+          ) : null}
+          <p className="mt-1 text-sm font-semibold text-ink-900">{price}</p>
+        </div>
+      </button>
+      <Link
+        href={href}
+        className="self-center text-xs font-semibold text-brand-600 hover:underline"
+      >
+        →
+      </Link>
+    </article>
+  );
+}

--- a/apps/public_www/src/components/sections/search/search-map-split-layout.tsx
+++ b/apps/public_www/src/components/sections/search/search-map-split-layout.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import type { Locale, SiteContent } from '@/content';
+import { ActivityGoogleMap } from '@/components/shared/maps/activity-google-map';
+import { isGoogleMapsEnabled } from '@/lib/google-maps/config';
+import { listingsWithCoordinates } from '@/lib/google-maps/coordinates';
+import type { ActivityListing } from '@/lib/activities/types';
+
+import { SearchMapListItem } from './search-map-list-item';
+
+interface SearchMapSplitLayoutProps {
+  readonly locale: Locale;
+  readonly copy: SiteContent['searchPage'];
+  readonly listings: readonly ActivityListing[];
+  readonly selectedId: string | null;
+  readonly onSelect: (activityId: string) => void;
+  readonly isLoading: boolean;
+}
+
+export function SearchMapSplitLayout({
+  locale,
+  copy,
+  listings,
+  selectedId,
+  onSelect,
+  isLoading,
+}: SearchMapSplitLayoutProps) {
+  const mappableCount = listingsWithCoordinates(listings).length;
+  const mapsEnabled = isGoogleMapsEnabled();
+
+  if (!mapsEnabled) {
+    return (
+      <p className="rounded-xl border border-brand-100 bg-brand-50 px-4 py-8 text-center text-ink-700">
+        {copy.mapUnavailableLabel}
+      </p>
+    );
+  }
+
+  return (
+    <div className="search-map-split-layout lg:grid lg:grid-cols-2 lg:gap-0">
+      <div className="search-map-split-layout__list max-h-[50vh] overflow-y-auto border-b border-brand-100 px-4 py-4 lg:max-h-[calc(100vh-12rem)] lg:border-b-0 lg:border-r">
+        {isLoading ? (
+          <p className="text-center text-sm text-ink-500">{copy.loadingMapLabel}</p>
+        ) : null}
+        {!isLoading && listings.length === 0 ? (
+          <p className="text-center text-sm text-ink-700">{copy.emptyLabel}</p>
+        ) : null}
+        {!isLoading && listings.length > 0 && mappableCount === 0 ? (
+          <p className="text-center text-sm text-ink-700">{copy.mapEmptyLabel}</p>
+        ) : null}
+        <ul className="space-y-3">
+          {listings.map((listing) => (
+            <li key={listing.activity.id}>
+              <SearchMapListItem
+                locale={locale}
+                listing={listing}
+                isSelected={selectedId === listing.activity.id}
+                imageFallbackLabel={copy.imageFallbackLabel}
+                onSelect={() => onSelect(listing.activity.id)}
+              />
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="search-map-split-layout__map sticky top-16 h-[50vh] lg:h-[calc(100vh-12rem)]">
+        {mappableCount > 0 ? (
+          <ActivityGoogleMap
+            locale={locale}
+            listings={listings}
+            selectedId={selectedId}
+            onSelect={onSelect}
+            className="h-full w-full"
+            ariaLabel={copy.mapAriaLabel}
+          />
+        ) : (
+          <div className="flex h-full items-center justify-center bg-brand-50 px-4 text-center text-sm text-ink-500">
+            {copy.mapEmptyLabel}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/public_www/src/components/shared/maps/activity-google-map.tsx
+++ b/apps/public_www/src/components/shared/maps/activity-google-map.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import { useEffect, useId, useRef } from 'react';
+
+import type { Locale } from '@/content';
+import {
+  centerForCoordinates,
+  HONG_KONG_CENTER,
+  listingCoordinate,
+  listingsWithCoordinates,
+} from '@/lib/google-maps/coordinates';
+import { loadGoogleMapsScript } from '@/lib/google-maps/load-script';
+import { getGoogleMapsConfig } from '@/lib/google-maps/config';
+import { listingTitle } from '@/lib/activities/listing-utils';
+import type { ActivityListing } from '@/lib/activities/types';
+
+interface ActivityGoogleMapProps {
+  readonly locale: Locale;
+  readonly listings: readonly ActivityListing[];
+  readonly selectedId: string | null;
+  readonly onSelect: (activityId: string) => void;
+  readonly className?: string;
+  readonly ariaLabel: string;
+}
+
+export function ActivityGoogleMap({
+  locale,
+  listings,
+  selectedId,
+  onSelect,
+  className = '',
+  ariaLabel,
+}: ActivityGoogleMapProps) {
+  const containerId = useId().replace(/:/g, '');
+  const containerRef = useRef<HTMLDivElement>(null);
+  const mapRef = useRef<google.maps.Map | null>(null);
+  const markersRef = useRef<google.maps.Marker[]>([]);
+
+  const listingIds = listings.map((listing) => listing.activity.id).join(',');
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+
+    const apiKey = getGoogleMapsConfig().apiKey;
+    if (!apiKey) {
+      return;
+    }
+
+    let cancelled = false;
+
+    loadGoogleMapsScript(apiKey)
+      .then(() => {
+        if (cancelled || !containerRef.current) {
+          return;
+        }
+
+        const mappableListings = listingsWithCoordinates(listings);
+        const coordinates = mappableListings
+          .map((listing) => listingCoordinate(listing))
+          .filter((value): value is NonNullable<typeof value> => value !== null);
+
+        const center = centerForCoordinates(
+          coordinates.length > 0 ? coordinates : [HONG_KONG_CENTER],
+        );
+
+        const map =
+          mapRef.current ??
+          new google.maps.Map(containerRef.current, {
+            center: new google.maps.LatLng(center.lat, center.lng),
+            zoom: coordinates.length === 1 ? 14 : 11,
+            mapTypeControl: false,
+            streetViewControl: false,
+            fullscreenControl: false,
+          });
+        mapRef.current = map;
+
+        for (const marker of markersRef.current) {
+          marker.setMap(null);
+        }
+        markersRef.current = [];
+
+        const bounds = new google.maps.LatLngBounds();
+        for (const listing of mappableListings) {
+          const coordinate = listingCoordinate(listing);
+          if (!coordinate) {
+            continue;
+          }
+          const position = new google.maps.LatLng(
+            coordinate.lat,
+            coordinate.lng,
+          );
+          bounds.extend(position);
+          const marker = new google.maps.Marker({
+            map,
+            position,
+            title: listingTitle(locale, listing),
+          });
+          marker.addListener('click', () => {
+            onSelect(listing.activity.id);
+          });
+          markersRef.current.push(marker);
+        }
+
+        if (coordinates.length > 1) {
+          map.fitBounds(bounds, 48);
+        }
+      })
+      .catch(() => {
+        // Map load errors are surfaced by the parent empty state.
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [listingIds, listings, locale, onSelect]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !selectedId) {
+      return;
+    }
+
+    const listing = listings.find((entry) => entry.activity.id === selectedId);
+    const coordinate = listing ? listingCoordinate(listing) : null;
+    if (!coordinate) {
+      return;
+    }
+
+    map.panTo(new google.maps.LatLng(coordinate.lat, coordinate.lng));
+    const mappableCount = listingsWithCoordinates(listings).length;
+    if (mappableCount === 1) {
+      map.setZoom(14);
+    }
+  }, [listings, selectedId]);
+
+  return (
+    <div
+      id={containerId}
+      ref={containerRef}
+      className={`activity-google-map ${className}`.trim()}
+      role="application"
+      aria-label={ariaLabel}
+    />
+  );
+}

--- a/apps/public_www/src/components/shared/search/region-map-link.tsx
+++ b/apps/public_www/src/components/shared/search/region-map-link.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import Link from 'next/link';
+
+import type { Locale } from '@/content';
+import {
+  buildMapSearchHref,
+  buildMapSearchHrefForRegion,
+} from '@/lib/activities/map-search-url';
+import type { SearchFiltersState } from '@/lib/activities/search-params';
+
+interface RegionMapLinkProps {
+  readonly locale: Locale;
+  readonly label: string;
+  readonly filters: SearchFiltersState;
+  readonly regionId?: string | null;
+  readonly className?: string;
+}
+
+export function RegionMapLink({
+  locale,
+  label,
+  filters,
+  regionId,
+  className = '',
+}: RegionMapLinkProps) {
+  const href =
+    regionId != null && regionId !== ''
+      ? buildMapSearchHrefForRegion(locale, filters, regionId)
+      : buildMapSearchHref(locale, filters);
+
+  return (
+    <Link
+      href={href}
+      className={`font-medium text-brand-600 underline-offset-2 hover:underline ${className}`.trim()}
+      onClick={(event) => {
+        event.stopPropagation();
+      }}
+    >
+      {label}
+    </Link>
+  );
+}

--- a/apps/public_www/src/content/en.json
+++ b/apps/public_www/src/content/en.json
@@ -21,7 +21,8 @@
       "search": "Search activities",
       "anywhere": "All Hong Kong",
       "anyAge": "Any age",
-      "anyType": "All types"
+      "anyType": "All types",
+      "openMapForAreaLabel": "Show activities on map for"
     },
     "searchPanel": {
       "title": "Search activities",
@@ -128,6 +129,7 @@
     "nearRegionTitle": "Activities in",
     "freeTrialLabel": "Free trial",
     "imageFallbackLabel": "Photo coming soon",
+    "mapAltLabel": "Map location",
     "errorLabel": "Unable to load activities.",
     "carousel": {
       "previousLabel": "Previous activities",
@@ -143,6 +145,10 @@
     "emptyLabel": "No activities match your search. Try different filters.",
     "errorLabel": "Unable to load activities.",
     "mapEmptyLabel": "No map locations for these results.",
+    "mapUnavailableLabel": "Google Maps is not configured for this environment.",
+    "mapAriaLabel": "Activity locations on Google Maps",
+    "loadingMapLabel": "Loading map...",
+    "mapAltLabel": "Map location",
     "freeTrialLabel": "Free trial",
     "imageFallbackLabel": "Photo coming soon"
   },

--- a/apps/public_www/src/content/zh-HK.json
+++ b/apps/public_www/src/content/zh-HK.json
@@ -21,7 +21,8 @@
       "search": "搜尋活動",
       "anywhere": "全港",
       "anyAge": "任何年齡",
-      "anyType": "所有類型"
+      "anyType": "所有類型",
+      "openMapForAreaLabel": "在地圖上顯示"
     },
     "searchPanel": {
       "title": "搜尋活動",
@@ -128,6 +129,7 @@
     "nearRegionTitle": "活動 —",
     "freeTrialLabel": "免費試堂",
     "imageFallbackLabel": "相片稍後提供",
+    "mapAltLabel": "地圖位置",
     "errorLabel": "無法載入活動。",
     "carousel": {
       "previousLabel": "上一組活動",
@@ -143,6 +145,10 @@
     "emptyLabel": "沒有符合的活動，請嘗試其他篩選。",
     "errorLabel": "無法載入活動。",
     "mapEmptyLabel": "這些結果沒有地圖位置。",
+    "mapUnavailableLabel": "此環境未設定 Google Maps。",
+    "mapAriaLabel": "Google 地圖上的活動位置",
+    "loadingMapLabel": "載入地圖中...",
+    "mapAltLabel": "地圖位置",
     "freeTrialLabel": "免費試堂",
     "imageFallbackLabel": "相片稍後提供"
   },

--- a/apps/public_www/src/lib/activities/map-search-url.ts
+++ b/apps/public_www/src/lib/activities/map-search-url.ts
@@ -1,0 +1,42 @@
+import type { Locale } from '@/content';
+import { homeWizardChoices } from '@/lib/home-wizard/choices';
+import { localizePath } from '@/lib/locale-routing';
+import type { ActivityListing } from '@/lib/activities/types';
+
+import {
+  buildSearchQueryString,
+  type SearchFiltersState,
+  type SearchViewMode,
+} from './search-params';
+
+export function regionIdForListing(listing: ActivityListing): string | null {
+  const areaId =
+    listing.location.regionAreaId ?? listing.location.areaId;
+  const match = homeWizardChoices.regions.find(
+    (region) => region.areaId === areaId,
+  );
+  return match?.id ?? null;
+}
+
+export function buildMapSearchHref(
+  locale: Locale,
+  filters: SearchFiltersState,
+): string {
+  const query = buildSearchQueryString(filters, { view: 'map' });
+  return query
+    ? `${localizePath('/search', locale)}?${query}`
+    : `${localizePath('/search', locale)}?view=map`;
+}
+
+export function buildMapSearchHrefForRegion(
+  locale: Locale,
+  baseFilters: SearchFiltersState,
+  regionId: string,
+): string {
+  return buildMapSearchHref(locale, {
+    ...baseFilters,
+    regionId,
+  });
+}
+
+export type { SearchViewMode };

--- a/apps/public_www/src/lib/activities/search-params.ts
+++ b/apps/public_www/src/lib/activities/search-params.ts
@@ -1,5 +1,7 @@
 import { homeWizardChoices } from '@/lib/home-wizard/choices';
 
+export type SearchViewMode = 'list' | 'map';
+
 export interface SearchFiltersState {
   readonly ageGroupId: string | null;
   readonly regionId: string | null;
@@ -68,7 +70,16 @@ export function parseSearchFiltersFromQuery(
   };
 }
 
-export function buildSearchQueryString(filters: SearchFiltersState): string {
+export function parseSearchViewMode(
+  searchParams: URLSearchParams,
+): SearchViewMode {
+  return searchParams.get('view') === 'map' ? 'map' : 'list';
+}
+
+export function buildSearchQueryString(
+  filters: SearchFiltersState,
+  options?: { readonly view?: SearchViewMode },
+): string {
   const params = new URLSearchParams();
   if (filters.ageGroupId) {
     params.set('age', filters.ageGroupId);
@@ -81,6 +92,9 @@ export function buildSearchQueryString(filters: SearchFiltersState): string {
   }
   if (filters.textQuery.trim()) {
     params.set('q', filters.textQuery.trim());
+  }
+  if (options?.view === 'map') {
+    params.set('view', 'map');
   }
   return params.toString();
 }

--- a/apps/public_www/src/lib/google-maps/config.ts
+++ b/apps/public_www/src/lib/google-maps/config.ts
@@ -1,0 +1,17 @@
+function trimEnv(value: string | undefined): string {
+  return (value ?? '').trim();
+}
+
+export interface GoogleMapsConfig {
+  readonly apiKey: string;
+}
+
+export function getGoogleMapsConfig(): GoogleMapsConfig {
+  return {
+    apiKey: trimEnv(process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY),
+  };
+}
+
+export function isGoogleMapsEnabled(): boolean {
+  return getGoogleMapsConfig().apiKey.length > 0;
+}

--- a/apps/public_www/src/lib/google-maps/coordinates.ts
+++ b/apps/public_www/src/lib/google-maps/coordinates.ts
@@ -1,0 +1,63 @@
+import type { ActivityListing } from '@/lib/activities/types';
+
+export interface MapCoordinate {
+  readonly lat: number;
+  readonly lng: number;
+}
+
+export const HONG_KONG_CENTER: MapCoordinate = {
+  lat: 22.3193,
+  lng: 114.1694,
+};
+
+export function listingCoordinate(
+  listing: ActivityListing,
+): MapCoordinate | null {
+  const { lat, lng } = listing.location;
+  if (lat === null || lng === null) {
+    return null;
+  }
+  return { lat, lng };
+}
+
+export function listingsWithCoordinates(
+  listings: readonly ActivityListing[],
+): readonly ActivityListing[] {
+  return listings.filter((listing) => listingCoordinate(listing) !== null);
+}
+
+export function boundsForCoordinates(
+  coordinates: readonly MapCoordinate[],
+): { readonly north: number; readonly south: number; readonly east: number; readonly west: number } | null {
+  if (coordinates.length === 0) {
+    return null;
+  }
+
+  let north = coordinates[0].lat;
+  let south = coordinates[0].lat;
+  let east = coordinates[0].lng;
+  let west = coordinates[0].lng;
+
+  for (const point of coordinates.slice(1)) {
+    north = Math.max(north, point.lat);
+    south = Math.min(south, point.lat);
+    east = Math.max(east, point.lng);
+    west = Math.min(west, point.lng);
+  }
+
+  return { north, south, east, west };
+}
+
+export function centerForCoordinates(
+  coordinates: readonly MapCoordinate[],
+): MapCoordinate {
+  const bounds = boundsForCoordinates(coordinates);
+  if (!bounds) {
+    return HONG_KONG_CENTER;
+  }
+
+  return {
+    lat: (bounds.north + bounds.south) / 2,
+    lng: (bounds.east + bounds.west) / 2,
+  };
+}

--- a/apps/public_www/src/lib/google-maps/load-script.ts
+++ b/apps/public_www/src/lib/google-maps/load-script.ts
@@ -1,0 +1,44 @@
+'use client';
+
+const SCRIPT_ID = 'siutindei-google-maps-script';
+let loadPromise: Promise<void> | null = null;
+
+export function loadGoogleMapsScript(apiKey: string): Promise<void> {
+  if (typeof window === 'undefined') {
+    return Promise.reject(new Error('Google Maps requires a browser.'));
+  }
+
+  if (window.google?.maps) {
+    return Promise.resolve();
+  }
+
+  if (loadPromise) {
+    return loadPromise;
+  }
+
+  loadPromise = new Promise((resolve, reject) => {
+    const existing = document.getElementById(SCRIPT_ID);
+    if (existing) {
+      existing.addEventListener('load', () => resolve(), { once: true });
+      existing.addEventListener(
+        'error',
+        () => reject(new Error('Google Maps failed to load.')),
+        { once: true },
+      );
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.id = SCRIPT_ID;
+    script.async = true;
+    script.defer = true;
+    script.src =
+      `https://maps.googleapis.com/maps/api/js?key=${encodeURIComponent(apiKey)}` +
+      '&loading=async';
+    script.onload = () => resolve();
+    script.onerror = () => reject(new Error('Google Maps failed to load.'));
+    document.head.appendChild(script);
+  });
+
+  return loadPromise;
+}

--- a/apps/public_www/src/lib/google-maps/region-centers.ts
+++ b/apps/public_www/src/lib/google-maps/region-centers.ts
@@ -1,0 +1,25 @@
+import { homeWizardChoices } from '@/lib/home-wizard/choices';
+
+import type { MapCoordinate } from './coordinates';
+
+const REGION_CENTERS: Record<string, MapCoordinate> = {
+  hong_kong_island: { lat: 22.2783, lng: 114.1747 },
+  kowloon: { lat: 22.3193, lng: 114.1694 },
+  new_territories: { lat: 22.45, lng: 114.17 },
+  islands: { lat: 22.2611, lng: 113.9465 },
+};
+
+export function centerForRegionId(regionId: string | null): MapCoordinate | null {
+  if (!regionId) {
+    return null;
+  }
+  const direct = REGION_CENTERS[regionId];
+  if (direct) {
+    return direct;
+  }
+  const region = homeWizardChoices.regions.find((entry) => entry.id === regionId);
+  if (!region) {
+    return null;
+  }
+  return REGION_CENTERS[region.id] ?? null;
+}

--- a/apps/public_www/src/lib/google-maps/static-map-url.ts
+++ b/apps/public_www/src/lib/google-maps/static-map-url.ts
@@ -1,0 +1,30 @@
+import type { MapCoordinate } from './coordinates';
+
+const STATIC_MAP_SIZE = {
+  card: { width: 600, height: 200 },
+  detail: { width: 800, height: 400 },
+} as const;
+
+export type StaticMapVariant = keyof typeof STATIC_MAP_SIZE;
+
+function encodeMarker(coordinate: MapCoordinate): string {
+  return `color:0x3a5ba0|${coordinate.lat},${coordinate.lng}`;
+}
+
+export function buildStaticMapUrl(params: {
+  readonly apiKey: string;
+  readonly coordinate: MapCoordinate;
+  readonly variant: StaticMapVariant;
+  readonly zoom?: number;
+}): string {
+  const size = STATIC_MAP_SIZE[params.variant];
+  const url = new URL('https://maps.googleapis.com/maps/api/staticmap');
+  url.searchParams.set('center', `${params.coordinate.lat},${params.coordinate.lng}`);
+  url.searchParams.set('zoom', String(params.zoom ?? 14));
+  url.searchParams.set('size', `${size.width}x${size.height}`);
+  url.searchParams.set('scale', '2');
+  url.searchParams.set('maptype', 'roadmap');
+  url.searchParams.append('markers', encodeMarker(params.coordinate));
+  url.searchParams.set('key', params.apiKey);
+  return url.toString();
+}

--- a/apps/public_www/src/types/google-maps.d.ts
+++ b/apps/public_www/src/types/google-maps.d.ts
@@ -1,0 +1,42 @@
+declare namespace google.maps {
+  class LatLng {
+    constructor(lat: number, lng: number);
+  }
+
+  class LatLngBounds {
+    extend(point: LatLng): void;
+  }
+
+  interface MapOptions {
+    center?: LatLng;
+    zoom?: number;
+    mapTypeControl?: boolean;
+    streetViewControl?: boolean;
+    fullscreenControl?: boolean;
+  }
+
+  class Map {
+    constructor(element: HTMLElement, options?: MapOptions);
+    fitBounds(bounds: LatLngBounds, padding?: number): void;
+    panTo(latLng: LatLng): void;
+    setZoom(zoom: number): void;
+  }
+
+  interface MarkerOptions {
+    map?: Map;
+    position?: LatLng;
+    title?: string;
+  }
+
+  class Marker {
+    constructor(options?: MarkerOptions);
+    setMap(map: Map | null): void;
+    addListener(eventName: string, handler: () => void): void;
+  }
+}
+
+interface Window {
+  google?: {
+    maps: typeof google.maps;
+  };
+}

--- a/apps/public_www/tests/lib/activities-search-params.test.ts
+++ b/apps/public_www/tests/lib/activities-search-params.test.ts
@@ -4,6 +4,7 @@ import {
   buildSearchQueryString,
   categoryIdsForTypes,
   parseSearchFiltersFromQuery,
+  parseSearchViewMode,
 } from '@/lib/activities/search-params';
 
 describe('search-params', () => {
@@ -22,6 +23,11 @@ describe('search-params', () => {
     expect(parsed.regionId).toBe('kowloon');
     expect(parsed.activityTypeIds).toEqual(['workshop', 'class']);
     expect(parsed.textQuery).toBe('music');
+  });
+
+  it('parses map view mode from the query string', () => {
+    const params = new URLSearchParams('view=map');
+    expect(parseSearchViewMode(params)).toBe('map');
   });
 
   it('maps activity types to category ids', () => {

--- a/apps/public_www/tests/lib/google-maps-static-map.test.ts
+++ b/apps/public_www/tests/lib/google-maps-static-map.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildStaticMapUrl } from '@/lib/google-maps/static-map-url';
+
+describe('buildStaticMapUrl', () => {
+  it('builds a Google Static Maps URL with a marker', () => {
+    const url = buildStaticMapUrl({
+      apiKey: 'test-key',
+      coordinate: { lat: 22.3193, lng: 114.1694 },
+      variant: 'card',
+    });
+
+    expect(url).toContain('maps.googleapis.com/maps/api/staticmap');
+    expect(url).toContain('22.3193');
+    expect(url).toContain('114.1694');
+    expect(url).toContain('key=test-key');
+  });
+});

--- a/apps/public_www/tests/lib/map-search-url.test.ts
+++ b/apps/public_www/tests/lib/map-search-url.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildMapSearchHref } from '@/lib/activities/map-search-url';
+import { DEFAULT_SEARCH_FILTERS } from '@/lib/activities/search-params';
+
+describe('buildMapSearchHref', () => {
+  it('includes view=map in the search URL', () => {
+    const href = buildMapSearchHref('en', {
+      ...DEFAULT_SEARCH_FILTERS,
+      regionId: 'kowloon',
+    });
+
+    expect(href).toBe('/en/search/?age=3-6&region=kowloon&view=map');
+  });
+});

--- a/docs/architecture/public-www.md
+++ b/docs/architecture/public-www.md
@@ -82,9 +82,13 @@ Source: [`apps/public_www`](../../apps/public_www).
   The home route renders `DiscoveryHomePage` (Airbnb-style discovery: sticky
   search header, category chips, horizontal listing carousels fed by
   `/v1/activities/search`).
-- **Search & detail:** `/[locale]/search/` (results grid + map panel) and
-  `/[locale]/activity/?id=<uuid>` (detail + WhatsApp CTA). Search uses browser-side
-  `fetch` to `NEXT_PUBLIC_SEARCH_API_BASE_URL` unless
+- **Search & detail:** `/[locale]/search/` (results grid, or `?view=map` for a
+  50/50 list + Google Maps split) and `/[locale]/activity/?id=<uuid>` (detail +
+  WhatsApp CTA). Optional `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` enables Static Maps
+  on listing cards, map markers on the split view, and CSP entries for
+  `maps.googleapis.com` / `maps.gstatic.com`. The search bar **area** label links
+  to the map split for the selected region. Search uses browser-side `fetch` to
+  `NEXT_PUBLIC_SEARCH_API_BASE_URL` unless
   `NEXT_PUBLIC_STAGING_SEARCH_DATA_ENABLED=true`, in which case listings are
   loaded at runtime from
   `{NEXT_PUBLIC_SITE_ORIGIN}/fixtures/activity_search_staging.json` (static


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Airbnb-style Google Maps to the public website when `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` is configured.

### Split map search (`/en/search/?view=map`)
- 50/50 layout on large screens: scrollable activity list on the left, interactive Google Map on the right
- Markers for activities with `location.lat` / `location.lng`; clicking a marker or list item syncs selection
- List/Map toggle chips on the search page

### Location title → map
- Search bar **Area** segment links directly to the map split for the current filters
- Region labels on listing cards link to the map view for that region

### Listing card mini-map
- Static Google Map inset at the bottom of each card image (when coordinates + API key exist)

### Infrastructure
- CSP extended for `maps.googleapis.com` / `maps.gstatic.com` when the API key is set at build time
- Documented in `docs/architecture/public-www.md` and `.env.example`

## Setup

Enable **Maps JavaScript API** and **Maps Static API** on your Google Cloud key, then set:

```
NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=your-key
```

in the public website build environment (staging/production GitHub env vars).

## Testing

- `cd apps/public_www && npm run typecheck && npm run lint`
- `npm test -- tests/lib/google-maps-static-map.test.ts tests/lib/map-search-url.test.ts tests/lib/activities-search-params.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4f33ce83-a328-4dbc-87d7-3c89efd15441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f33ce83-a328-4dbc-87d7-3c89efd15441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

