### PR TITLE
Align staging assert:build-env-contract env with production build

### DIFF
--- a/.github/workflows/deploy-public-www.yml
+++ b/.github/workflows/deploy-public-www.yml
@@ -65,6 +65,8 @@ jobs:
         env:
           NEXT_PUBLIC_SITE_ORIGIN: ${{ steps.resolve_public_site_config.outputs.staging_site_origin }}
           NEXT_PUBLIC_SITE_NAME: ${{ vars.NEXT_PUBLIC_SITE_NAME || steps.resolve_public_site_config.outputs.site_name }}
+          NEXT_PUBLIC_SITE_TAGLINE: ${{ vars.NEXT_PUBLIC_SITE_TAGLINE || steps.resolve_public_site_config.outputs.site_tagline }}
+          NEXT_PUBLIC_STAGING_SEARCH_DATA_ENABLED: ${{ vars.STAGING_SEARCH_DATA_ENABLED || 'true' }}
 
       - name: Restore Next.js build cache
         uses: actions/cache@v5


### PR DESCRIPTION
The contract step omitted NEXT_PUBLIC_STAGING_SEARCH_DATA_ENABLED, so CI treated staging as live-search and required API secrets that staging skips.