### PR TITLE
Move public search caching from API Gateway cache to the CloudFront edge

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -108,7 +108,9 @@ repo root
 - Never call boto3 cognito-idp directly from in-VPC Lambdas; always use the proxy.
 - Search responses use cursor pagination.
 - Flutter uses Amplify config passed via dart-define.
-- API Gateway caching enabled for search.
+- Public search caching is at the CloudFront edge (public-www distribution
+ `/v1/activities/search` behavior); the API Gateway stage cache cluster is
+ disabled.
 - Admin CRUD routes exist under /admin and require admin group membership.
 - Database roles include activities_app (read) and activities_admin (write).
 - Admin group is created by CDK.

--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -1830,15 +1830,14 @@ export class ApiStack extends cdk.Stack {
         loggingLevel: apigateway.MethodLoggingLevel.INFO,
         dataTraceEnabled: false,
         tracingEnabled: true,
-        cacheClusterEnabled: true,
-        cacheClusterSize: "0.5",
-        cacheDataEncrypted: true,
-        methodOptions: {
-          "/v1/activities/search/GET": {
-            cachingEnabled: true,
-            cacheTtl: cdk.Duration.minutes(5),
-          },
-        },
+        // Response caching for the public search endpoint has been moved to the
+        // CloudFront edge (see PublicWwwStack `/v1/activities/search` behavior).
+        // The API Gateway stage cache cluster is a fixed hourly charge
+        // (0.5 GB ≈ $0.028/hr ≈ $20/mo) regardless of traffic, which dominated
+        // the API Gateway bill while serving only this one low-traffic method.
+        // CloudFront caching is usage-based and falls within the always-free
+        // tier at current volumes, so the cluster is disabled here.
+        cacheClusterEnabled: false,
       },
     });
     api.deploymentStage.node.addDependency(apiAccessLogGroupRetention);

--- a/backend/infrastructure/lib/public-www-stack.ts
+++ b/backend/infrastructure/lib/public-www-stack.ts
@@ -25,13 +25,27 @@ import { Construct } from "constructs";
 //   * Optional WAF (us-east-1) attached via CfnCondition; reuses the same WAF
 //     WebACL ARN as the admin web distribution.
 //
-// Future extension (NOT included in scaffolding):
-//   * /www/* CloudFront behavior with allow-list CloudFront Function pointing
-//     at the API Gateway origin (see evolvesprouts public-www-stack for the
-//     full pattern). When adding that, serialize CloudFront Function updates
-//     within an environment to avoid hitting the regional CloudFront Functions
-//     API rate limit (`addDependency` chain).
+// Search API edge caching:
+//   * A `/v1/activities/search` CloudFront behavior fronts the public search
+//     endpoint, pointing at the API Gateway custom domain origin. This replaces
+//     the (fixed-cost) API Gateway stage cache cluster with usage-based
+//     CloudFront edge caching. An allow-list CloudFront Function rejects any
+//     method other than GET/HEAD/OPTIONS on that path. CloudFront Function
+//     creation is serialized via an `addDependency` chain so a single deploy
+//     does not breach the regional CloudFront Functions API rate limit.
 // -----------------------------------------------------------------------------
+
+// Query-string + auth headers forwarded to the API Gateway origin on a cache
+// miss. Caching does NOT vary on these headers (public search results are the
+// same for every caller), so a single cache entry is shared across viewers.
+const SEARCH_API_PROXY_PATH = "/v1/activities/search";
+const SEARCH_API_FORWARDED_HEADERS = [
+  "x-api-key",
+  "x-device-attestation",
+  "Accept",
+];
+// Edge cache TTL mirrors the previous API Gateway method cache (5 minutes).
+const SEARCH_API_CACHE_TTL = cdk.Duration.minutes(5);
 
 interface WebsiteEnvironmentConfig {
   readonly idPrefix: "PublicWww" | "PublicWwwStaging";
@@ -43,12 +57,17 @@ interface WebsiteEnvironmentConfig {
   readonly addNoIndexHeader: boolean;
   readonly hasWafWebAclArn: cdk.CfnCondition;
   readonly wafWebAclArn: cdk.CfnParameter;
+  readonly searchApiOriginDomain: string;
+  readonly searchApiCachePolicy: cloudfront.ICachePolicy;
+  readonly searchApiOriginRequestPolicy: cloudfront.IOriginRequestPolicy;
 }
 
 interface WebsiteEnvironmentResources {
   readonly bucket: s3.Bucket;
   readonly distribution: cloudfront.Distribution;
   readonly loggingBucket: s3.Bucket;
+  readonly pathRewriteFunction: cloudfront.Function;
+  readonly searchProxyFunction: cloudfront.Function;
 }
 
 const PUBLIC_WWW_HEADER_CONTENT_SECURITY_POLICY = [
@@ -141,6 +160,59 @@ export class PublicWwwStack extends cdk.Stack {
       ),
     });
 
+    // Origin domain for the public search API (API Gateway custom domain, e.g.
+    // siutindei-api.lx-software.com). CloudFront proxies + caches the public
+    // search endpoint here instead of paying for the API Gateway stage cache.
+    const searchApiOriginDomain = new cdk.CfnParameter(
+      this,
+      "SearchApiProxyOriginDomain",
+      {
+        type: "String",
+        description:
+          "API Gateway custom domain that serves the public search endpoint " +
+          "(e.g. siutindei-api.lx-software.com). CloudFront caches " +
+          "GET /v1/activities/search responses at the edge.",
+        allowedPattern: "^[a-z0-9.-]+$",
+        constraintDescription: "Must be a bare DNS hostname (no scheme/path).",
+      },
+    );
+
+    // Shared cache + origin-request policies (CloudFront policies are global to
+    // the account; create once and reuse across both website environments).
+    const searchApiCachePolicy = new cloudfront.CachePolicy(
+      this,
+      "SearchApiCachePolicy",
+      {
+        comment: "Edge cache for the public activity-search endpoint.",
+        defaultTtl: SEARCH_API_CACHE_TTL,
+        // minTtl 0 lets the origin shorten caching via Cache-Control if needed;
+        // maxTtl caps it at the intended 5-minute window.
+        minTtl: cdk.Duration.seconds(0),
+        maxTtl: SEARCH_API_CACHE_TTL,
+        // Vary the cache on every query string (search filters + cursor) so
+        // distinct queries get distinct entries, but NOT on auth headers so a
+        // single cached response is shared across all callers.
+        queryStringBehavior: cloudfront.CacheQueryStringBehavior.all(),
+        headerBehavior: cloudfront.CacheHeaderBehavior.none(),
+        cookieBehavior: cloudfront.CacheCookieBehavior.none(),
+        enableAcceptEncodingGzip: true,
+        enableAcceptEncodingBrotli: true,
+      },
+    );
+    const searchApiOriginRequestPolicy = new cloudfront.OriginRequestPolicy(
+      this,
+      "SearchApiOriginRequestPolicy",
+      {
+        comment: "Forward search query + auth headers to the API origin.",
+        queryStringBehavior:
+          cloudfront.OriginRequestQueryStringBehavior.all(),
+        headerBehavior: cloudfront.OriginRequestHeaderBehavior.allowList(
+          ...SEARCH_API_FORWARDED_HEADERS,
+        ),
+        cookieBehavior: cloudfront.OriginRequestCookieBehavior.none(),
+      },
+    );
+
     const productionResources = this.createWebsiteEnvironment({
       idPrefix: "PublicWww",
       environmentLabel: "production",
@@ -155,6 +227,9 @@ export class PublicWwwStack extends cdk.Stack {
       addNoIndexHeader: false,
       hasWafWebAclArn,
       wafWebAclArn,
+      searchApiOriginDomain: searchApiOriginDomain.valueAsString,
+      searchApiCachePolicy,
+      searchApiOriginRequestPolicy,
     });
     this.bucket = productionResources.bucket;
     this.distribution = productionResources.distribution;
@@ -172,10 +247,29 @@ export class PublicWwwStack extends cdk.Stack {
       addNoIndexHeader: true,
       hasWafWebAclArn,
       wafWebAclArn,
+      searchApiOriginDomain: searchApiOriginDomain.valueAsString,
+      searchApiCachePolicy,
+      searchApiOriginRequestPolicy,
     });
     this.stagingBucket = stagingResources.bucket;
     this.stagingDistribution = stagingResources.distribution;
     this.stagingLoggingBucket = stagingResources.loggingBucket;
+
+    // Serialize CloudFront Function creation/updates across both environments
+    // into a single linear chain. Deploying all four functions in parallel can
+    // breach the regional CloudFront Functions API rate limit, so each function
+    // depends on the previous one:
+    //   prod path-rewrite → prod search-proxy → staging path-rewrite → staging
+    //   search-proxy.
+    productionResources.searchProxyFunction.node.addDependency(
+      productionResources.pathRewriteFunction,
+    );
+    stagingResources.pathRewriteFunction.node.addDependency(
+      productionResources.searchProxyFunction,
+    );
+    stagingResources.searchProxyFunction.node.addDependency(
+      stagingResources.pathRewriteFunction,
+    );
 
     new cdk.CfnOutput(this, "PublicWwwBucketName", {
       value: this.bucket.bucketName,
@@ -368,6 +462,40 @@ function handler(event) {
       },
     );
 
+    // Allow-list CloudFront Function for the search-proxy behavior: only safe
+    // read methods reach the API origin; anything else is rejected at the edge.
+    const searchProxyFunction = new cloudfront.Function(
+      this,
+      `${config.idPrefix}SearchProxyAllowlistFunction`,
+      {
+        comment:
+          "Allow only GET/HEAD/OPTIONS on the public search proxy behavior.",
+        runtime: cloudfront.FunctionRuntime.JS_2_0,
+        code: cloudfront.FunctionCode.fromInline(`
+function handler(event) {
+  var request = event.request;
+  var method = request.method;
+  if (method === 'GET' || method === 'HEAD' || method === 'OPTIONS') {
+    return request;
+  }
+  return {
+    statusCode: 405,
+    statusDescription: 'Method Not Allowed',
+    headers: { 'allow': { value: 'GET, HEAD, OPTIONS' } },
+  };
+}
+`),
+      },
+    );
+
+    const searchApiOrigin = new origins.HttpOrigin(
+      config.searchApiOriginDomain,
+      {
+        protocolPolicy: cloudfront.OriginProtocolPolicy.HTTPS_ONLY,
+        originSslProtocols: [cloudfront.OriginSslPolicy.TLS_V1_2],
+      },
+    );
+
     const distribution = new cloudfront.Distribution(
       this,
       `${config.idPrefix}Distribution`,
@@ -410,6 +538,25 @@ function handler(event) {
             },
           ],
         },
+        additionalBehaviors: {
+          // Public activity-search endpoint: proxied + cached at the edge.
+          // Uses the search cache/origin-request policies (no static-site
+          // path rewrite, no static response-headers/CSP policy).
+          [SEARCH_API_PROXY_PATH]: {
+            origin: searchApiOrigin,
+            viewerProtocolPolicy:
+              cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+            allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
+            cachePolicy: config.searchApiCachePolicy,
+            originRequestPolicy: config.searchApiOriginRequestPolicy,
+            functionAssociations: [
+              {
+                function: searchProxyFunction,
+                eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
+              },
+            ],
+          },
+        },
       },
     );
 
@@ -428,6 +575,8 @@ function handler(event) {
       bucket,
       distribution,
       loggingBucket,
+      pathRewriteFunction,
+      searchProxyFunction,
     };
   }
 }

--- a/backend/infrastructure/params/production.json
+++ b/backend/infrastructure/params/production.json
@@ -30,6 +30,7 @@
   "PublicWwwCertificateArn": "arn:aws:acm:us-east-1:588024549699:certificate/ea553e5a-e7af-43ba-bdd4-d46e2f8458aa",
   "PublicWwwStagingDomainName": "siutindei-www-staging.lx-software.com",
   "PublicWwwStagingCertificateArn": "arn:aws:acm:us-east-1:588024549699:certificate/ea553e5a-e7af-43ba-bdd4-d46e2f8458aa",
+  "SearchApiProxyOriginDomain": "siutindei-api.lx-software.com",
   "WafWebAclArn": "arn:aws:wafv2:us-east-1:588024549699:global/webacl/lxsoftware-siutindei-cloudfront-waf/100ec25a-0688-43fc-bc1f-6bb531af0355",
   "ApiCustomDomainName": "siutindei-api.lx-software.com",
   "ApiCustomDomainCertificateArn": "arn:aws:acm:ap-southeast-1:588024549699:certificate/af726e1f-444b-47e6-906e-ce9e0925bde4",

--- a/docs/architecture/aws-assets-map.md
+++ b/docs/architecture/aws-assets-map.md
@@ -294,8 +294,10 @@ For each function above, the following resources are created:
 - Logging Level: INFO
 - Data Trace: Disabled
 - X-Ray Tracing: Enabled
-- Caching: Enabled (0.5 GB cache cluster, encrypted)
-- Cache TTL: 5 minutes for `/v1/activities/search/GET`
+- Caching: Disabled (no stage cache cluster). Public search responses are
+  cached at the CloudFront edge instead — see the public-website distribution
+  `/v1/activities/search` behavior in
+  [`public-www.md`](./public-www.md#search-api-edge-caching).
 
 **CORS Configuration:**
 - Allowed Origins: From `CORS_ALLOWED_ORIGINS` env var or context, defaults to `capacitor://localhost`, `ionic://localhost`, `http://localhost`
@@ -310,7 +312,7 @@ and [`docs/api/admin.yaml`](../api/admin.yaml).
 | Resource Path | Method | Authorization | Integration | Notes |
 |--------------|--------|---------------|-------------|-------|
 | `/health` | GET | IAM | `HealthCheckFunction` | Health check |
-| `/v1/activities/search` | GET | Device Attestation + API Key | `SiutindeiSearchFunction` | Cached |
+| `/v1/activities/search` | GET | Device Attestation + API Key | `SiutindeiSearchFunction` | Cached at CloudFront edge (5-min TTL) |
 | `/v1/admin/{resource}` | GET, POST | Admin Group | `SiutindeiAdminFunction` | CRUD (orgs, locations, activities, pricing, schedules) |
 | `/v1/admin/{resource}/{id}` | GET, PUT, DELETE | Admin Group | `SiutindeiAdminFunction` | CRUD by ID |
 | `/v1/admin/organizations/{id}/media` | POST, DELETE | Admin Group | `SiutindeiAdminFunction` | Media upload/delete |

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -146,7 +146,11 @@ parallel environments (production + staging) inside a single CDK stack
 - Hosted UI uses OAuth code flow with callback/logout URLs supplied via CDK
   parameters.
 - API keys are rotated every 90 days by a scheduled Lambda.
-- API Gateway method caching enabled for search responses (5-minute TTL).
+- Public search responses are cached at the CloudFront edge (5-minute TTL) via
+  the public-website distribution's `/v1/activities/search` behavior; the API
+  Gateway stage cache cluster is disabled. CloudFront caching is usage-based
+  (within the free tier at current volumes), whereas the API Gateway cache
+  cluster was a fixed hourly charge that dominated the API Gateway bill.
 - See the OpenAPI specs for per-endpoint authentication requirements:
   [`docs/api/admin.yaml`](../api/admin.yaml).
 

--- a/docs/architecture/public-www.md
+++ b/docs/architecture/public-www.md
@@ -205,22 +205,43 @@ CloudFront’s response headers policy applies a smaller CSP fragment
 (`base-uri`, `object-src`, `frame-ancestors` only); the meta tag carries
 the full policy above.
 
-## Future work — `/www/*` API proxy
+## Search API edge caching
 
-When the public website needs to call the backend API, port the
-`/www/*` CloudFront behavior pattern from
-`lcacchiani/evolvesprouts/backend/infrastructure/lib/public-www-stack.ts`:
+The public website's activity-search calls are proxied and cached at the
+CloudFront edge instead of paying for an API Gateway stage cache cluster
+(a fixed hourly charge that dominated the API Gateway bill). Both website
+distributions (production + staging) carry an extra cache behavior:
 
-- A `wwwProxyAllowlistFunction` CloudFront Function runs at
-  `viewer-request` and rejects any path/method pair that isn't in the
-  allow-list.
-- The behavior forwards to an `HttpOrigin` pointing at the API Gateway
-  custom domain (already provisioned at
-  `siutindei-api.lx-software.com`).
-- Add the dependency chain across all CloudFront Functions in an
-  environment (see comment in `evolvesprouts/public-www-stack.ts`) to
-  serialize updates within the regional rate limit.
-- Mirror the maintenance-mode swap in `deploy-public-www.sh`
-  (`apply_www_proxy_mode`).
-- Update the smoke-test workflow to include the `--api-only` and `--all`
-  scopes (the current scaffolding only covers pages).
+| Item | Value |
+|---|---|
+| Path pattern | `/v1/activities/search` (exact path; admin/other API paths are **not** exposed) |
+| Origin | `HttpOrigin` → API Gateway custom domain from the `SearchApiProxyOriginDomain` parameter (`siutindei-api.lx-software.com`), HTTPS-only, TLS 1.2+ |
+| Allowed methods | `GET`, `HEAD`, `OPTIONS` |
+| Allow-list function | `${env}SearchProxyAllowlistFunction` CloudFront Function (viewer-request) returns `405` for any other method |
+| Cache policy (`SearchApiCachePolicy`) | TTL min `0` / default `300s` / max `300s`; cache key = **all query strings**, **no** headers, **no** cookies (a single cached entry is shared across all callers) |
+| Origin-request policy (`SearchApiOriginRequestPolicy`) | Forwards all query strings + `x-api-key`, `x-device-attestation`, `Accept` headers to the origin on a cache **miss** |
+
+CloudFront Function creation is serialized across both environments via an
+`addDependency` chain (prod path-rewrite → prod search-proxy → staging
+path-rewrite → staging search-proxy) so a single deploy does not breach the
+regional CloudFront Functions API rate limit.
+
+To route traffic through the edge cache, the website build must point
+`NEXT_PUBLIC_SEARCH_API_BASE_URL` at the website's own origin (e.g.
+`https://siutindei-www.lx-software.com`) rather than directly at
+`siutindei-api.lx-software.com`; `src/lib/activities/search-client.ts`
+resolves `new URL('/v1/activities/search', base)`, which then hits this
+behavior same-origin. With same-origin requests the CSP `connect-src 'self'`
+already covers the call (no API host needs to be added to CSP).
+
+**Security/behavioral note:** on a cache **hit** CloudFront serves the cached
+response without re-invoking the origin, so the per-request `x-api-key` /
+`x-device-attestation` checks (anti-abuse controls, not data protection) are
+not enforced for cached entries. This matches the intent of a *public* search
+endpoint and the prior API Gateway method-cache behavior of returning cached
+results; abuse protection at the edge is provided by the CloudFront WAF
+WebACL. Only the exact `/v1/activities/search` path is proxied, so admin
+endpoints (`/v1/admin/*`) are never reachable through the website domain.
+Distribution-level custom error responses (403/404 → `/404.html`) still apply
+to this behavior; validate API error handling on staging before pointing
+production traffic at the edge.

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -138,6 +138,28 @@ const deviceAttestationFailClosed = new cdk.CfnParameter(
 );
 ```
 
+### Edge caching of the public search endpoint
+
+`GET /v1/activities/search` is cached at the CloudFront edge via the
+public-website distribution (see
+[`public-www.md`](./public-www.md#search-api-edge-caching)). On a cache **hit**,
+CloudFront serves the response without re-invoking the origin, so the
+per-request `x-api-key` and `x-device-attestation` checks are **not** enforced
+for cached entries. This is acceptable because:
+
+- These controls are **anti-abuse / rate-limiting**, not data protection — the
+  search results are public.
+- Only the exact `/v1/activities/search` path is proxied; admin endpoints
+  (`/v1/admin/*`) are never reachable through the website domain.
+- Edge abuse protection is provided by the CloudFront WAF WebACL.
+- On a cache **miss**, the request is forwarded to the API Gateway origin with
+  the auth headers intact, where the device-attestation authorizer and API key
+  are enforced as normal.
+
+The cache key includes all query strings but **no** request headers, so a
+single cached response is shared across callers (no per-token cache
+fragmentation, no leakage of caller-specific data).
+
 ---
 
 ## API Security


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Cost analysis of the AWS account (`588024549699`, `ap-southeast-1`) showed the API Gateway bill is **~99.4% fixed cache-cluster cost**, not traffic:

| Usage type (May 2026) | Cost | Share |
|---|---|---|
| `ApiGatewayCacheUsage:0.5GB` | **$41.67** | 99.4% |
| Requests (REST + HTTP) | $0.24 | 0.6% |

The cost is flat (~$40–42/mo) regardless of request volume because the 0.5 GB stage cache cluster is billed per hour (~$0.028/hr), while it serves only the single low-traffic `GET /v1/activities/search` method. CloudFront caching is usage-based and already bills ~$0 for the account's traffic (within the always-free 1 TB / 10M-request tier), so moving search caching to the edge eliminates essentially the entire charge.

## What changed (CDK)

- **`api-stack.ts`** — disabled the API Gateway stage cache cluster (`cacheClusterEnabled: false`; removed cache size, encryption, and the per-method caching block).
- **`public-www-stack.ts`** — added a `/v1/activities/search` cache behavior to **both** public-website distributions (production + staging):
  - `HttpOrigin` → API Gateway custom domain (`SearchApiProxyOriginDomain` parameter = `siutindei-api.lx-software.com`), HTTPS-only / TLS 1.2+.
  - `SearchApiCachePolicy` — TTL min 0 / default 300s / max 300s; cache key = all query strings, **no** headers, **no** cookies (one shared cached entry per query).
  - `SearchApiOriginRequestPolicy` — forwards query strings + `x-api-key` / `x-device-attestation` / `Accept` to the origin on a cache miss.
  - Allow-list CloudFront Function (viewer-request) returning `405` for non-`GET/HEAD/OPTIONS`.
  - `addDependency` chain serializing all four CloudFront Functions (prod path-rewrite → prod search-proxy → staging path-rewrite → staging search-proxy) to avoid the regional CloudFront Functions rate limit.
- **`params/production.json`** — added `SearchApiProxyOriginDomain`.
- **`deploy-backend.yml` / `cdk-diff.yml`** — added `SearchApiProxyOriginDomain` to the public-www parameter allow-list so the deploy routes the value to the public-www stack (the workflow defaults unlisted keys to the API stack, which caused the initial `CloudFormation Parameters are missing a value: SearchApiProxyOriginDomain` deploy failure).
- **Docs** — `public-www.md`, `security.md`, `decisions.md`, `aws-assets-map.md`, `.cursorrules` updated to reflect the migration (incl. the edge-cache auth tradeoff).

Only the exact `/v1/activities/search` path is proxied; admin endpoints (`/v1/admin/*`) are never reachable through the website domain.

## Estimated savings

~**$20.83/mo (~$250/yr)** on the siutindei API (the disabled cache cluster). The other ~$20.83/mo lives on `evolvesprouts-api`, whose CDK is in a **separate repo** (`lcacchiani/evolvesprouts`) and is not editable here — that cache is already redundant (the API is fronted by CloudFront) and can be disabled with the same one-line `cacheClusterEnabled: false` change there.

## Activation follow-up (operational, not in this PR)

To route traffic through the new edge cache, set the production/staging `NEXT_PUBLIC_SEARCH_API_BASE_URL` GitHub Environment variable to the website origin (e.g. `https://siutindei-www.lx-software.com`) instead of `siutindei-api.lx-software.com`. `search-client.ts` resolves `new URL('/v1/activities/search', base)`, so the call then hits the behavior same-origin (CSP `connect-src 'self'` covers it). The cost saving from disabling the API Gateway cache applies on the next infra deploy regardless.

## Security/behavioral note

On a cache **hit** CloudFront serves the response without re-invoking the origin, so per-request `x-api-key` / `x-device-attestation` (anti-abuse, not data protection) are not enforced for cached entries — acceptable for a public search endpoint and consistent with the prior method-cache behavior; edge abuse protection is the CloudFront WAF WebACL. Distribution-level custom error pages (403/404 → `/404.html`) still apply to this behavior, so validate API error handling on staging before repointing production traffic.

## Testing

This is un-deployable-from-here IaC, validated via build + CloudFormation synthesis + deploy-routing simulation:

- ✅ `npm run build` (tsc) — infrastructure package compiles.
- ✅ `cdk synth lxsoftware-siutindei` — synthesizes; template shows `CacheClusterEnabled: false` and no cache size / per-method caching.
- ✅ Synth assertion harness on `PublicWwwStack` — both distributions carry the `/v1/activities/search` behavior (GET/HEAD/OPTIONS, cache + origin-request policies, allow-list function); cache policy = 300s TTL / query=all / headers=none; origin-request policy forwards `x-api-key` + `x-device-attestation`; 4 CloudFront Functions present; dependency chain serialized.
- ✅ Deploy param-routing simulation — `SearchApiProxyOriginDomain` now resolves to `['lxsoftware-siutindei-public-www']` with value `siutindei-api.lx-software.com`.

No UI changes, so no GUI walkthrough applies.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-324c67f4-53a9-4236-973f-65f78e65d53d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-324c67f4-53a9-4236-973f-65f78e65d53d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

