### PR TITLE
fix(infra): suppress Checkov CKV_AWS_120 on API Gateway stage

### DIFF
--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -1841,6 +1841,43 @@ export class ApiStack extends cdk.Stack {
     api.deploymentStage.node.addDependency(apiAccessLogGroupRetention);
     api.deploymentStage.node.addDependency(apiAccessLogGroupKey);
 
+    // Suppress Checkov CKV_AWS_120 ("Ensure API Gateway caching is enabled")
+    // on the deployment stage. Stage caching is intentionally disabled (see the
+    // `cacheClusterEnabled: false` rationale above): response caching for the
+    // public search endpoint is handled at the CloudFront edge via the
+    // public-website distribution's `/v1/activities/search` behavior, which is
+    // usage-based and within the free tier at current volumes. The API Gateway
+    // stage cache cluster is a fixed hourly charge that dominated the API
+    // Gateway bill while serving only one low-traffic method. This is the
+    // documented architectural decision (docs/architecture/decisions.md and
+    // docs/architecture/overview.md, "Caching"). Re-enabling the stage cache
+    // requires removing this suppression and setting cachingEnabled: true on
+    // each cacheable method.
+    const cfnApiStage = api.deploymentStage.node
+      .defaultChild as apigateway.CfnStage | undefined;
+    if (!cfnApiStage) {
+      throw new Error(
+        "ApiStack: expected api.deploymentStage.node.defaultChild to be " +
+          "apigateway.CfnStage so Checkov CKV_AWS_120 suppression can be attached"
+      );
+    }
+    cfnApiStage.addMetadata("checkov", {
+      skip: [
+        {
+          id: "CKV_AWS_120",
+          comment:
+            "Stage caching is intentionally disabled (cacheClusterEnabled: " +
+            "false); no method sets cachingEnabled: true. Public search " +
+            "responses are edge-cached on the public-website CloudFront " +
+            "distribution (/v1/activities/search behavior, see " +
+            "backend/infrastructure/lib/public-www-stack.ts). The API Gateway " +
+            "stage cache cluster is a fixed hourly charge and is not " +
+            "cost-effective for a single low-traffic method. See " +
+            "docs/architecture/decisions.md (Caching).",
+        },
+      ],
+    });
+
     // -------------------------------------------------------------------------
     // Gateway Responses – add CORS headers to API Gateway error responses
     //

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -151,6 +151,12 @@ parallel environments (production + staging) inside a single CDK stack
   Gateway stage cache cluster is disabled. CloudFront caching is usage-based
   (within the free tier at current volumes), whereas the API Gateway cache
   cluster was a fixed hourly charge that dominated the API Gateway bill.
+  Because the stage cache is intentionally off, Checkov rule CKV_AWS_120
+  ("Ensure API Gateway caching is enabled") is suppressed inline on the stage
+  resource (`Metadata.checkov.skip`) in
+  [`api-stack.ts`](../../backend/infrastructure/lib/api-stack.ts). Re-enabling
+  the stage cache requires removing that suppression and setting
+  `cachingEnabled: true` on each cacheable method.
 - See the OpenAPI specs for per-endpoint authentication requirements:
   [`docs/api/admin.yaml`](../api/admin.yaml).
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -157,7 +157,11 @@ pull requests for dependency updates:
 
 ## Caching
 
-- API Gateway method caching enabled for search queries (5-minute TTL).
+- Public search responses are cached at the CloudFront edge (5-minute TTL) via
+  the public-website distribution's `/v1/activities/search` behavior. The API
+  Gateway stage cache cluster is intentionally disabled (Checkov CKV_AWS_120 is
+  suppressed on the stage); see [`decisions.md`](decisions.md) for the cost
+  rationale.
 - Cache keys include all search query parameters.
 - Client-side caching with stale-while-revalidate in Flutter (planned).
 - See [`docs/architecture/cloudflare-optimization.md`](cloudflare-optimization.md) for edge caching strategy.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves the Checkov finding **CKV_AWS_120 — "Ensure API Gateway caching is enabled"** on `AWS::ApiGateway::Stage.SiutindeiApiDeploymentStageprodC8434C74` (issue #97).

The API Gateway stage cache cluster is **intentionally disabled** (`cacheClusterEnabled: false`): response caching for the public search endpoint was moved to the CloudFront edge (public-website distribution `/v1/activities/search` behavior), which is usage-based and within the free tier. The stage cache cluster is a fixed hourly charge that dominated the API Gateway bill while serving one low-traffic method.

Since enabling stage caching is the wrong call here, this adds an inline Checkov suppression on the stage resource (`Metadata.checkov.skip`) with a justification comment — mirroring the fix in `lcacchiani/evolvesprouts`.

## Changes

- `backend/infrastructure/lib/api-stack.ts`: attach `checkov` skip metadata for `CKV_AWS_120` to `api.deploymentStage` (the L1 `CfnStage`), with a fail-fast guard if the default child isn't a `CfnStage`.
- `docs/architecture/decisions.md`: document the CKV_AWS_120 suppression and how to re-enable stage caching.
- `docs/architecture/overview.md`: correct the stale "API Gateway method caching enabled" note to reflect CloudFront edge caching.

## Testing

- ✅ `npm run build` (tsc)
- ✅ `npm run test:infra`
- ✅ `cdk synth` then `checkov -c CKV_AWS_120` on the generated template: the stage is now **SKIPPED** (0 failed, 1 skipped) with the justification comment. With the suppression stripped, the same resource is **FAILED** (1 failed) — confirming the fix targets the exact finding.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d132404a-f8f2-42fd-961c-f81630acfc69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d132404a-f8f2-42fd-961c-f81630acfc69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

