### PR TITLE
fix(infra): skip Checkov CKV_AWS_120 via .checkov.yaml to clear code-scanning alert

### DIFF
--- a/backend/infrastructure/.checkov.yaml
+++ b/backend/infrastructure/.checkov.yaml
@@ -61,3 +61,13 @@ skip-check:
   # enforced on the RDS Proxy for all Lambda application connections.
   # Architecture: Lambda -> RDS Proxy (IAM auth) -> Aurora Cluster (password auth)
   - CKV_AWS_162  # IAM authentication enabled
+
+  # API Gateway stage caching - ONLY affects the public API deployment stage
+  # Stage caching is intentionally disabled (cacheClusterEnabled: false); no
+  # method sets cachingEnabled: true. Public search responses are edge-cached
+  # on the public-website CloudFront distribution (/v1/activities/search
+  # behavior, see backend/infrastructure/lib/public-www-stack.ts). The API
+  # Gateway stage cache cluster is a fixed hourly charge and is not
+  # cost-effective for a single low-traffic method.
+  # See docs/architecture/decisions.md (Caching).
+  - CKV_AWS_120  # API Gateway caching enabled

--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -1841,42 +1841,16 @@ export class ApiStack extends cdk.Stack {
     api.deploymentStage.node.addDependency(apiAccessLogGroupRetention);
     api.deploymentStage.node.addDependency(apiAccessLogGroupKey);
 
-    // Suppress Checkov CKV_AWS_120 ("Ensure API Gateway caching is enabled")
-    // on the deployment stage. Stage caching is intentionally disabled (see the
-    // `cacheClusterEnabled: false` rationale above): response caching for the
-    // public search endpoint is handled at the CloudFront edge via the
-    // public-website distribution's `/v1/activities/search` behavior, which is
-    // usage-based and within the free tier at current volumes. The API Gateway
-    // stage cache cluster is a fixed hourly charge that dominated the API
-    // Gateway bill while serving only one low-traffic method. This is the
-    // documented architectural decision (docs/architecture/decisions.md and
-    // docs/architecture/overview.md, "Caching"). Re-enabling the stage cache
-    // requires removing this suppression and setting cachingEnabled: true on
-    // each cacheable method.
-    const cfnApiStage = api.deploymentStage.node
-      .defaultChild as apigateway.CfnStage | undefined;
-    if (!cfnApiStage) {
-      throw new Error(
-        "ApiStack: expected api.deploymentStage.node.defaultChild to be " +
-          "apigateway.CfnStage so Checkov CKV_AWS_120 suppression can be attached"
-      );
-    }
-    cfnApiStage.addMetadata("checkov", {
-      skip: [
-        {
-          id: "CKV_AWS_120",
-          comment:
-            "Stage caching is intentionally disabled (cacheClusterEnabled: " +
-            "false); no method sets cachingEnabled: true. Public search " +
-            "responses are edge-cached on the public-website CloudFront " +
-            "distribution (/v1/activities/search behavior, see " +
-            "backend/infrastructure/lib/public-www-stack.ts). The API Gateway " +
-            "stage cache cluster is a fixed hourly charge and is not " +
-            "cost-effective for a single low-traffic method. See " +
-            "docs/architecture/decisions.md (Caching).",
-        },
-      ],
-    });
+    // Checkov CKV_AWS_120 ("Ensure API Gateway caching is enabled") is
+    // intentionally suppressed for the deployment stage. Stage caching is
+    // disabled (see the `cacheClusterEnabled: false` rationale above): response
+    // caching for the public search endpoint is handled at the CloudFront edge
+    // via the public-website distribution's `/v1/activities/search` behavior.
+    // The suppression lives in `.checkov.yaml` (skip-check) rather than inline
+    // CDK metadata, because skip-check excludes the finding from SARIF output
+    // entirely instead of merely marking it skipped (inline metadata
+    // suppressions still surface as GitHub Code Scanning alerts). See
+    // docs/architecture/decisions.md (Caching).
 
     // -------------------------------------------------------------------------
     // Gateway Responses – add CORS headers to API Gateway error responses

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -152,11 +152,13 @@ parallel environments (production + staging) inside a single CDK stack
   (within the free tier at current volumes), whereas the API Gateway cache
   cluster was a fixed hourly charge that dominated the API Gateway bill.
   Because the stage cache is intentionally off, Checkov rule CKV_AWS_120
-  ("Ensure API Gateway caching is enabled") is suppressed inline on the stage
-  resource (`Metadata.checkov.skip`) in
-  [`api-stack.ts`](../../backend/infrastructure/lib/api-stack.ts). Re-enabling
-  the stage cache requires removing that suppression and setting
-  `cachingEnabled: true` on each cacheable method.
+  ("Ensure API Gateway caching is enabled") is suppressed via `skip-check` in
+  [`.checkov.yaml`](../../backend/infrastructure/.checkov.yaml). The skip lives
+  in the config file (not inline CDK metadata) so the finding is excluded from
+  SARIF output entirely rather than merely marked skipped — inline suppressions
+  still surface as GitHub Code Scanning alerts. Re-enabling the stage cache
+  requires removing that skip and setting `cachingEnabled: true` on each
+  cacheable method.
 - See the OpenAPI specs for per-endpoint authentication requirements:
   [`docs/api/admin.yaml`](../api/admin.yaml).
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -160,8 +160,8 @@ pull requests for dependency updates:
 - Public search responses are cached at the CloudFront edge (5-minute TTL) via
   the public-website distribution's `/v1/activities/search` behavior. The API
   Gateway stage cache cluster is intentionally disabled (Checkov CKV_AWS_120 is
-  suppressed on the stage); see [`decisions.md`](decisions.md) for the cost
-  rationale.
+  suppressed via `skip-check` in `.checkov.yaml`); see
+  [`decisions.md`](decisions.md) for the cost rationale.
 - Cache keys include all search query parameters.
 - Client-side caching with stale-while-revalidate in Flutter (planned).
 - See [`docs/architecture/cloudflare-optimization.md`](cloudflare-optimization.md) for edge caching strategy.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves GitHub Code Scanning alert [#97](https://github.com/lcacchiani/siutindei/security/code-scanning/97) — Checkov `CKV_AWS_120` ("Ensure API Gateway caching is enabled").

PR #340 disabled the API Gateway stage cache (`cacheClusterEnabled: false`) and suppressed `CKV_AWS_120` with an **inline** `Metadata.checkov.skip` on the stage resource. As documented in `.checkov.yaml`, inline metadata suppressions still emit a SARIF result (marked skipped), so the finding surfaced as a new Code Scanning alert (#97) rather than being excluded.

This moves the suppression to the `skip-check` list in `.checkov.yaml`, which excludes the check from SARIF output entirely so it no longer appears in Code Scanning — mirroring the earlier `CKV_AWS_162` fix (commit `12826d0`).

## Changes

- `backend/infrastructure/.checkov.yaml`: add `CKV_AWS_120` to `skip-check` with justification.
- `backend/infrastructure/lib/api-stack.ts`: remove the now-redundant inline `addMetadata("checkov", ...)` suppression; replace with an explanatory comment pointing to the config-level skip.
- `docs/architecture/decisions.md`, `docs/architecture/overview.md`: update the caching notes to reference the `.checkov.yaml` skip.

## Verification

Synthesized the CDK and re-ran Checkov with the repo config:

- Before: `checkov failed results in SARIF: 1` (`CKV_AWS_120`).
- After: `checkov failed results in SARIF: 0`; `CKV_AWS_120` absent from both results and the rules list.
- `npm run build` (tsc) passes; `cdk synth` succeeds.

The architectural decision (stage cache off; public search cached at the CloudFront edge) is unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ccc87ef8-731f-434c-aae7-453e1105b076"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ccc87ef8-731f-434c-aae7-453e1105b076"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

