### PR TITLE
ci(security): add 7-day Dependabot cooldown to all ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "ci"
     labels:
@@ -26,6 +28,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore(deps)"
     labels:
@@ -58,6 +62,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore(deps)"
     labels:
@@ -101,6 +107,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore(deps)"
     labels:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the Semgrep code scanning findings for rule `dependabot-missing-cooldown`.

None of the four `package-ecosystem` entries in `.github/dependabot.yml` (github-actions, npm, pip, pub) configured a `cooldown`, so Dependabot could propose a package version the moment it was published — a window commonly exploited by supply-chain attacks and a source of unstable releases. Each entry now has:

```yaml
cooldown:
  default-days: 7
```

Dependabot will wait 7 days after a new version is published before opening an update PR. The Semgrep rule requires a `cooldown` block with `default-days` of at least 7 on every entry. See the [Dependabot cooldown docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#cooldown).

## Verification

Ran the exact registry rule locally against `.github/dependabot.yml`:

- Before: `Findings: 4 (4 blocking)` — one per ecosystem entry
- After: `Ran 1 rule on 1 file: 0 findings.`

YAML validated with a parse check.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99be3b09-923c-45fd-ae7a-18d2b053da1b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99be3b09-923c-45fd-ae7a-18d2b053da1b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

